### PR TITLE
updated SensiML app to use 1.5MHz PDM clock for audio

### DIFF
--- a/qf_apps/qf_mqttsn_ai_app/README.md
+++ b/qf_apps/qf_mqttsn_ai_app/README.md
@@ -27,7 +27,7 @@ and appropriate ARM GCC toolchain to build the project
 3. Reset the board to start running the AI application.
 
 For data collection, building an AI model, and recognition 
-please refer to https://sensiml.com/ and https://sensiml.com/documentation/guides/getting-started/index.html
+please refer to [SensiML QF] and [SensiML Getting Started]
 
 Using with an AD7476 ADC module
 ------------
@@ -45,7 +45,7 @@ Connect a [PmodAD1] module to the quickfeather using the following pinout
 Connect desired sensor to the A0 pin on the PmodAD1 module.
 
 Reset the Quickfeather board to start running the AI application.
-Refer [SensiML Getting Started] to collect data or get inferences from this connected sensor.
+Refer [SensiML QF] to collect data or get inferences from this connected sensor.
 
 MQTT-SN over USB-serial Notes
 ------------
@@ -59,6 +59,6 @@ transmit function to enter busy-wait state when the FIFO fills-up, this applicat
 messages only if the FIFO is empty.
 
 [s3-gateware]: https://github.com/QuickLogic-Corp/s3-gateware
-[SensiML]: https://sensiml.com/
+[SensiML QF]: https://sensiml.com/documentation/firmware/quicklogic-quickfeather/quicklogic-quickfeather.html
 [SensiML Getting Started]: https://sensiml.com/documentation/guides/getting-started/index.html
 [PmodAD1]: https://reference.digilentinc.com/reference/pmod/pmodad1/start

--- a/qf_apps/qf_mqttsn_ai_app/inc/Fw_global_config.h
+++ b/qf_apps/qf_mqttsn_ai_app/inc/Fw_global_config.h
@@ -188,7 +188,7 @@ extern int FPGA_FFE_LOADED;
 #define CONST_FREQ (1)
 
 // Enable ADC FPGA Driver
-#define AD7476_FPGA_DRIVER   0
+#define AD7476_FPGA_DRIVER   1
 
 #if (FEATURE_USBSERIAL == 1) && (AD7476_FPGA_DRIVER == 1)
 #error "FEATURE_USBSERIAL and AD7476_FPGA_DRIVER are both enabled, Please select only of these FPGA IP features"
@@ -199,6 +199,9 @@ extern int FPGA_FFE_LOADED;
 //
 ///* enable the AUDIO driver */
 #define AUDIO_DRIVER    1    // Set 1 to enable audio sampling
+
+#define PDM2DEC_FACT    48   // Use 1.5MHz PDM Clock
+
 //
 ///* enable LPSD mode of AUDIO IP*/
 //#define ENABLE_LPSD    0 //Set to 1 enable, 0 to disable LPSD


### PR DESCRIPTION
This pull-request fixes the issue observed with Audio clipping when performing data capture using the qf_mqttsn_ai_app.
The PDM Mic IM69D130 mounted on the quickfeather board works only in 4 different PDM clock frequency bands (1) 400-950kHz, (2) 1.05-1.9MHz, (3) 2.1-2.65MHz, and (4) 2.9-3.3MHz. This PR update uses 1.5MHz PDM clock.