### PR TITLE
Bootloader uart

### DIFF
--- a/HAL/inc/eoss3_hal_uart.h
+++ b/HAL/inc/eoss3_hal_uart.h
@@ -141,7 +141,9 @@ typedef enum
 #define UART_ID_DBG UART_ID_HW
 #endif
 
+#ifndef UART_ID_BOOTLOADER
 #define UART_ID_BOOTLOADER  UART_ID_HW
+#endif
 
 
 /*! \struct UartHandler eoss3_hal_uart.h "inc/eoss3_hal_uart.h"

--- a/HAL/inc/eoss3_hal_uart.h
+++ b/HAL/inc/eoss3_hal_uart.h
@@ -136,15 +136,6 @@ typedef enum
 #if !defined(UART_ID_CONSOLE)   /* most often, the UART_HW */
 #define UART_ID_CONSOLE UART_ID_USBSERIAL
 #endif
-#if !defined(UART_ID_DBG)
-/* most often, the UART_HW but could be disabled */
-#define UART_ID_DBG UART_ID_HW
-#endif
-
-#ifndef UART_ID_BOOTLOADER
-#define UART_ID_BOOTLOADER  UART_ID_HW
-#endif
-
 
 /*! \struct UartHandler eoss3_hal_uart.h "inc/eoss3_hal_uart.h"
  * 	\brief UART configuration structure filled in by user.

--- a/qf_apps/qf_bootloader/inc/Fw_global_config.h
+++ b/qf_apps/qf_bootloader/inc/Fw_global_config.h
@@ -41,7 +41,10 @@
 // #define UART_ID_SEMBUF    5 // Write datat to semihost and buffer
 // #define UART_ID_USBSERIAL    6   // Write data to USB serial port
 #define DEBUG_UART UART_ID_HW  // Write debug data to semihost
-     
+
+// Set the UART ID to use for bootloader
+#define UART_ID_BOOTLOADER UART_ID_USBSERIAL
+
 //#define USE_SEMIHOSTING     1       // 1 => use semihosting, 0 => use UART_ID_HW
 
 #define SIZEOF_DBGBUFFER    2048    // Number of characters in circular debug buffer

--- a/qf_apps/qf_bootloader/readme.md
+++ b/qf_apps/qf_bootloader/readme.md
@@ -24,3 +24,9 @@ bootfpga	    |Used	|0x0002_0000|	0x0002_0000|	0x0003_FFFF	|	 131,072 |	 131,072 
 appfpga	        |Future	|0x0004_0000|	0x0002_0000|	0x0005_FFFF	|	 262,144 |	 131,072 |	 393,216 
 appffe	        |Future	|0x0006_0000|	0x0002_0000|	0x0007_FFFF	|	 393,216 |	 131,072 |	 524,288 
 M4app	        |Used	|0x0008_0000|	0x0006_E000|	0x000E_DFFF	|	 524,288 |	 450,560 |	 974,848 
+
+Communication Interface
+-----------------------
+
+This bootloader project uses USB-Serial interface available on the Quickfeather board to receive and transmit commands from TinyFPGA Programmer.  
+

--- a/qf_apps/qf_bootloader/src/pincfg_table.c
+++ b/qf_apps/qf_bootloader/src/pincfg_table.c
@@ -180,7 +180,7 @@ PadConfig pincfg_table[] =
     .ucMode = PAD_MODE_INPUT_EN,
     .ucPull = PAD_NOPULL, //PAD_PULLUP,//PAD_NOPULL,
   },
-  
+#if (FEATURE_USBSERIAL == 1)
   //------------- USB ---------------//
    { // Pad 37 -- USB Pullup control
     .ucPin = PAD_37,
@@ -212,7 +212,7 @@ PadConfig pincfg_table[] =
     .ucSpeed = PAD_SLEW_RATE_SLOW,
     .ucSmtTrg = PAD_SMT_TRIG_DIS,
   },
-
+#endif
   //------------- Buttons ---------------//
    { // Pad 6 -- User Buttion 
     .ucPin = PAD_6,

--- a/qf_apps/qf_bootloader/src/program_flash.c
+++ b/qf_apps/qf_bootloader/src/program_flash.c
@@ -71,8 +71,8 @@ void program_flash( void *pParameter )
         // Get pkt (first 5 bytes)
         while (ipkt != 5) {
             vTaskDelay(0);
-            if( uart_rx_available( UART_ID_USBSERIAL ) ){
-                c = uart_rx( UART_ID_USBSERIAL  );
+            if( uart_rx_available( UART_ID_BOOTLOADER ) ){
+                c = uart_rx( UART_ID_BOOTLOADER  );
                 //First 5 bytes are pkt
                 atflPkt[ipkt++] = c;
                 if (atflPkt[0] == 0) {
@@ -90,8 +90,8 @@ void program_flash( void *pParameter )
 
         // Grab the write data
         while (icmd < kbWrite) {
-            if( uart_rx_available( UART_ID_USBSERIAL ) ){
-                c = uart_rx( UART_ID_USBSERIAL  );
+            if( uart_rx_available( UART_ID_BOOTLOADER ) ){
+                c = uart_rx( UART_ID_BOOTLOADER  );
                 atflCmd[icmd++] = c;
             }
         }
@@ -101,19 +101,19 @@ void program_flash( void *pParameter )
             dbg_str("Release Deep Power-Down() ... ");
             spi_flash_cmd(atflCmd, kbWrite, atflResponse, kbRead, CMD_NoResponse);
             dbg_str("Done\n");
-            uart_tx_buf(UART_ID_USBSERIAL, atflResponse, kbRead);
+            uart_tx_buf(UART_ID_BOOTLOADER, atflResponse, kbRead);
             break;
         case 0x9F:
             dbg_str("Read ID() ... ");
             spi_flash_cmd(atflCmd, kbWrite, atflResponse, kbRead, CMD_WithResponse);
             xval = (atflResponse[2] << 16) | (atflResponse[1] << 8) | (atflResponse[0] << 0);
             dbg_str_hex32("Done", xval);
-            uart_tx_buf(UART_ID_USBSERIAL, atflResponse, kbRead);
+            uart_tx_buf(UART_ID_BOOTLOADER, atflResponse, kbRead);
             break;
         case 0x05:
             spi_flash_cmd(atflCmd, kbWrite, atflResponse, kbRead, CMD_WithResponse);
             xval = (atflResponse[1] << 8) | (atflResponse[0] << 0);
-            uart_tx_buf(UART_ID_USBSERIAL, atflResponse, kbRead);
+            uart_tx_buf(UART_ID_BOOTLOADER, atflResponse, kbRead);
             break;
         case 0x20:
             xaddr = (atflCmd[1] << 16) | (atflCmd[2] << 8) | atflCmd[3];
@@ -151,7 +151,7 @@ void program_flash( void *pParameter )
         case 0x0B:
             xaddr = (atflCmd[1] << 16) | (atflCmd[2] << 8) | atflCmd[3];
             spi_flash_cmd(atflCmd, kbWrite, atflResponse, kbRead, READ_CMD);
-            uart_tx_raw_buf(UART_ID_USBSERIAL, atflResponse, kbRead);
+            uart_tx_raw_buf(UART_ID_BOOTLOADER, atflResponse, kbRead);
             break;
         default:
             dbg_str_hex8("Unknown OpCode", (int)atflCmd[0]);

--- a/qf_apps/qf_bootloader/src/usb_fpga_loader.c
+++ b/qf_apps/qf_bootloader/src/usb_fpga_loader.c
@@ -69,6 +69,7 @@ int check_fpga_crc(int image_size, uint32_t expected_crc)
 */
 int load_usb_flasher(void)
 {
+#if FEATURE_USBSERIAL
   unsigned char *bufPtr;
   uint32_t image_crc, image_size;
   
@@ -104,7 +105,9 @@ int load_usb_flasher(void)
   for (int i = 0; i != 4000000; i++) ;   // Give it time to enumerate
 
   // remind what to do when done programming
-  dbg_str("FPGA Programmed\nPresss Reset button after flashing ..\n");
+  dbg_str("FPGA Programmed\n");
+#endif
+  dbg_str("Presss Reset button after flashing ..\n");
   //wait for the reset button to be pressed
   program_flash();
   NVIC_SystemReset();

--- a/qf_apps/qf_bootloader/src/usb_fpga_loader.c
+++ b/qf_apps/qf_bootloader/src/usb_fpga_loader.c
@@ -69,7 +69,7 @@ int check_fpga_crc(int image_size, uint32_t expected_crc)
 */
 int load_usb_flasher(void)
 {
-#if FEATURE_USBSERIAL
+#if (UART_ID_BOOTLOADER == UART_ID_USBSERIAL)
   unsigned char *bufPtr;
   uint32_t image_crc, image_size;
   

--- a/qf_apps/qf_loadflash/inc/Fw_global_config.h
+++ b/qf_apps/qf_loadflash/inc/Fw_global_config.h
@@ -88,7 +88,11 @@
 // #define UART_ID_FPGA      3 // second uart if part of FPGA
 // #define UART_ID_BUFFER    4 // Write data to buffer
 // #define UART_ID_SEMBUF    5 // Write datat to semihost and buffer
+// #define UART_ID_USBSERIAL    6   // Write data to USB serial port
 #define DEBUG_UART UART_ID_HW        // the hard UART on the S3
+
+// Set the UART ID to use for bootloader
+#define UART_ID_BOOTLOADER UART_ID_USBSERIAL
 
 #define USE_SEMIHOSTING     1       // 1 => use semihosting, 0 => use UART_ID_HW
 

--- a/qf_apps/qf_loadflash/src/main.c
+++ b/qf_apps/qf_loadflash/src/main.c
@@ -106,11 +106,12 @@ int main(void)
     
     S3x_Clk_Enable(S3X_A1_CLK);
     S3x_Clk_Enable(S3X_CFG_DMA_A1_CLK);
-    
+#if (FEATURE_USBSERIAL == 1)
     load_fpga(axFPGABitStream_length,axFPGABitStream);
     // Use 0x6140 as the USB serial product ID (USB PID)
     HAL_usbserial_init2(false, false, 0x6140);          // Start USB serial not using interrupts
     for (int i = 0; i != 4000000; i++) ;   // Give it time to enumerate
+#endif
     LoadFlash_Task_Init();
     /* Start the tasks and timer running */
     vTaskStartScheduler();

--- a/qf_apps/qf_loadflash/src/pincfg_table.c
+++ b/qf_apps/qf_loadflash/src/pincfg_table.c
@@ -180,7 +180,7 @@ PadConfig pincfg_table[] =
     .ucMode = PAD_MODE_INPUT_EN,
     .ucPull = PAD_NOPULL, //PAD_PULLUP,//PAD_NOPULL,
   },
-  
+#if (FEATURE_USBSERIAL == 1)
   //------------- USB ---------------//
    { // Pad 37 -- USB Pullup control
     .ucPin = PAD_37,
@@ -212,7 +212,7 @@ PadConfig pincfg_table[] =
     .ucSpeed = PAD_SLEW_RATE_SLOW,
     .ucSmtTrg = PAD_SMT_TRIG_DIS,
   },
-
+#endif
   //------------- Buttons ---------------//
    { // Pad 6 -- User Buttion 
     .ucPin = PAD_6,

--- a/qf_apps/qf_loadflash/src/program_flash.c
+++ b/qf_apps/qf_loadflash/src/program_flash.c
@@ -71,8 +71,8 @@ void program_flash( void *pParameter )
         // Get pkt (first 5 bytes)
         while (ipkt != 5) {
             vTaskDelay(0);
-            if( uart_rx_available( UART_ID_USBSERIAL ) ){
-                c = uart_rx( UART_ID_USBSERIAL  );
+            if( uart_rx_available( UART_ID_BOOTLOADER ) ){
+                c = uart_rx( UART_ID_BOOTLOADER  );
                 //First 5 bytes are pkt
                 atflPkt[ipkt++] = c;
                 if (atflPkt[0] == 0) {
@@ -90,8 +90,8 @@ void program_flash( void *pParameter )
 
         // Grab the write data
         while (icmd < kbWrite) {
-            if( uart_rx_available( UART_ID_USBSERIAL ) ){
-                c = uart_rx( UART_ID_USBSERIAL  );
+            if( uart_rx_available( UART_ID_BOOTLOADER ) ){
+                c = uart_rx( UART_ID_BOOTLOADER  );
                 atflCmd[icmd++] = c;
             }
         }
@@ -101,19 +101,19 @@ void program_flash( void *pParameter )
             dbg_str("Release Deep Power-Down() ... ");
             spi_flash_cmd(atflCmd, kbWrite, atflResponse, kbRead, CMD_NoResponse);
             dbg_str("Done\n");
-            uart_tx_buf(UART_ID_USBSERIAL, atflResponse, kbRead);
+            uart_tx_buf(UART_ID_BOOTLOADER, atflResponse, kbRead);
             break;
         case 0x9F:
             dbg_str("Read ID() ... ");
             spi_flash_cmd(atflCmd, kbWrite, atflResponse, kbRead, CMD_WithResponse);
             xval = (atflResponse[2] << 16) | (atflResponse[1] << 8) | (atflResponse[0] << 0);
             dbg_str_hex32("Done", xval);
-            uart_tx_buf(UART_ID_USBSERIAL, atflResponse, kbRead);
+            uart_tx_buf(UART_ID_BOOTLOADER, atflResponse, kbRead);
             break;
         case 0x05:
             spi_flash_cmd(atflCmd, kbWrite, atflResponse, kbRead, CMD_WithResponse);
             xval = (atflResponse[1] << 8) | (atflResponse[0] << 0);
-            uart_tx_buf(UART_ID_USBSERIAL, atflResponse, kbRead);
+            uart_tx_buf(UART_ID_BOOTLOADER, atflResponse, kbRead);
             break;
         case 0x20:
             xaddr = (atflCmd[1] << 16) | (atflCmd[2] << 8) | atflCmd[3];
@@ -151,7 +151,7 @@ void program_flash( void *pParameter )
         case 0x0B:
             xaddr = (atflCmd[1] << 16) | (atflCmd[2] << 8) | atflCmd[3];
             spi_flash_cmd(atflCmd, kbWrite, atflResponse, kbRead, READ_CMD);
-            uart_tx_raw_buf(UART_ID_USBSERIAL, atflResponse, kbRead);
+            uart_tx_raw_buf(UART_ID_BOOTLOADER, atflResponse, kbRead);
             break;
         default:
             dbg_str_hex8("Unknown OpCode", (int)atflCmd[0]);


### PR DESCRIPTION
Bootloader project updated to use UART_ID_BOOTLOADER macro to specify the communication interface for the TinyFPGA-Programmer.

Loadflash project updated to use UART_ID_BOOTLOADER macro to specify the communication interface for the TinyFPGA-Programmer