### PR TITLE
change qf_helloworldsw project to use QORC_TC_PATH variable

### DIFF
--- a/qf_apps/qf_helloworldsw/GCC_Project/config.mk
+++ b/qf_apps/qf_helloworldsw/GCC_Project/config.mk
@@ -96,28 +96,28 @@ TMPVAR = $(subst \, ,${APP_DIR})
 PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
-FIND_TOOL_DIR := $(shell where arm-none-eabi-gcc)
-ifndef FIND_TOOL_DIR
-$(info using recursive search)
-FIND_TOOL_DIR := $(shell where /r c:\progra~2 arm-none-eabi-gcc)
-endif
+#FIND_TOOL_DIR := $(shell where arm-none-eabi-gcc)
+#ifndef FIND_TOOL_DIR
+#$(info using recursive search)
+#FIND_TOOL_DIR := $(shell where /r c:\progra~2 arm-none-eabi-gcc)
+#endif
 
-ifdef FIND_TOOL_DIR
-export TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
-endif
+#ifdef FIND_TOOL_DIR
+#export QORC_TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
+#endif
 
 #Override with your own tool direcoty
-#export TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+#export QORC_TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in environment! #########)
 exit
 endif
 
-export NM="$(TC_PATH)\arm-none-eabi-nm"
-export LD="$(TC_PATH)\arm-none-eabi-gcc"
-export AS="$(TC_PATH)\arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)\arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)\arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)\arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)\arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)\arm-none-eabi-objcopy"
 ################
 else
 ################ Linux ###################
@@ -143,29 +143,29 @@ TMPVAR = $(subst ${DIR_SEP}, ,${APP_DIR})
 PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell whereis arm-none-eabi-gcc))
-export TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+#FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell whereis arm-none-eabi-gcc))
+#export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
 
 # Allow TOOL to be provided on the command line
-# ie;   make -f Makefile TC_PATH=/some/path/
+# ie;   make -f Makefile QORC_TC_PATH=/some/path/
 
-ifndef TC_PATH
+#ifndef QORC_TC_PATH
 #Override with your own tool directory
 #use full path. do not use ~/ as a relative path
-#export TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
-#export TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
-export TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
-endif
+#export QORC_TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
+#export QORC_TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
+#export QORC_TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
+#endif
 
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in environment! #########)
 exit
 endif
-export NM="$(TC_PATH)/arm-none-eabi-nm"
-export LD="$(TC_PATH)/arm-none-eabi-gcc"
-export AS="$(TC_PATH)/arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)/arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)/arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)/arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)/arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)/arm-none-eabi-objcopy"
 ################
 endif
 ################


### PR DESCRIPTION
as a starting point to support multiple gcc-arm-embedded toolchains being installed on a user's system, introduce `QORC_TC_PATH` which should be defined by the user before invoking `make`.
The `config.mk` is updated to remove the "find tool" method, and only reports an error if the `QORC_TC_PATH` is not defined, and stops build.

For example, if the extract path for gcc zip is:
`/usr/share`
and the version being used is:
`gcc-arm-none-eabi-9-2020-q2-update`
then, the environment should have
`export QORC_TC_PATH=/usr/share/gcc-arm-none-eabi-9-2020-q2-update/bin`

currently, only the `qf_helloworldsw` is modified to reflect this change, for the purpose of review.
If this method seems to be acceptable, we can change all the makefiles to use a similar approach.