### PR TITLE
add eclipse instruction in repo readme and RTD setup steps

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -409,3 +409,8 @@ project directories, for example qorc-sdk/qf_apps/qf_myapp
     :alt: Travis (.com) branch
     :target: https://travis-ci.com/QuickLogic-Corp/qorc-sdk
 
+
+Using Eclipse to Build/Debug applications
+-----------------------------------------
+
+Please refer to `Using Eclipse <https://github.com/QuickLogic-Corp/qorc-sdk/blob/master/using_eclipse.rst>`__ .

--- a/docs/source/qorc-setup/qorc-setup.rst
+++ b/docs/source/qorc-setup/qorc-setup.rst
@@ -2,7 +2,14 @@
 Setup
 =====
 
-The recommended way to setup the qorc-sdk and the dependencies is to follow the quick start which will allow new users to quickly get up and running with building, flashing and running applications on the QuickFeather Development Kit.
+   1. :doc:`/qorc-setup/quickstart` : The recommended way to setup the qorc-sdk and the dependencies is to follow the quick start which will allow new users to quickly get up and running with building, flashing and running applications on the QuickFeather Development Kit.
+
+   2. :doc:`/qorc-setup/using_eclipse` : A guide to setup build and debug of qorc application using Eclipse Embedded CDT. 
 
 
-.. include:: /../../quickstart.rst
+.. toctree::
+   :hidden:
+   :maxdepth: 2
+
+   quickstart.rst
+   using_eclipse.rst

--- a/docs/source/qorc-setup/quickstart.rst
+++ b/docs/source/qorc-setup/quickstart.rst
@@ -1,0 +1,7 @@
+.. include:: /common.rst
+
+.. include:: /../../quickstart.rst
+
+.. toctree::
+   :hidden:
+   :maxdepth: 2

--- a/docs/source/qorc-setup/using_eclipse.rst
+++ b/docs/source/qorc-setup/using_eclipse.rst
@@ -1,0 +1,7 @@
+.. include:: /common.rst
+
+.. include:: /../../using_eclipse.rst
+
+.. toctree::
+   :hidden:
+   :maxdepth: 2


### PR DESCRIPTION
* added pointer to eclipse instructions from main README.rst
* added eclipse setup in the RTD QORC Setup section.