### PR TITLE
Rename TC_PATH to QORC_TC_PATH, add export to env setup.

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -130,8 +130,8 @@ fi
 
 
 printf "    initializing toolchain.\n"
-export PATH=${PWD}/arm_toolchain_install/gcc-arm-none-eabi-9-2020-q2-update/bin:$PATH
-export QORC_TC_PATH=${PWD}/arm_toolchain_install/gcc-arm-none-eabi-9-2020-q2-update/bin
+export PATH=$ARM_TOOLCHAIN_INSTALL_DIR/bin:$PATH
+export QORC_TC_PATH=$ARM_TOOLCHAIN_INSTALL_DIR/bin
 
 
 ACTUAL_ARM_TOOLCHAIN_GCC_PATH=`which arm-none-eabi-gcc`

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -61,7 +61,7 @@ printf "executing envsetup.sh from:\n%s\n" ${PWD}
 #---------------------------------------------------------
 printf "\n[0] are we inside qorc-sdk?\n"
 
-# there seems to be strange behaviour on certain systems, the URL obtained below 
+# there seems to be strange behaviour on certain systems, the URL obtained below
 # seems to have some letter lowercase, whereas on most, it is as it should be.
 # to avoid this stuff we do all lowercase only comparison, use "tr" to do this.
 GIT_REPO_URL_LOWERCASE=`git config --get remote.origin.url | tr '[:upper:]' '[:lower:]'`
@@ -72,7 +72,7 @@ if [ ! "$GIT_REPO_URL_LOWERCASE" = "$GIT_REPO_URL_EXPECTED_LOWERCASE" ]; then
 
         printf "This script should be executed from within the qorc-sdk directory!\n"
         return
-        
+
     fi
 
 fi
@@ -112,7 +112,7 @@ printf "    ok.\n"
 #---------------------------------------------------------
 printf "\n[2] check arm gcc toolchain\n"
 if [ ! -d $ARM_TOOLCHAIN_INSTALL_DIR ]; then
-    
+
     printf "    creating toolchain directory : %s\n" "${PWD}/arm_toolchain_install"
     mkdir arm_toolchain_install
 
@@ -120,7 +120,7 @@ if [ ! -d $ARM_TOOLCHAIN_INSTALL_DIR ]; then
 
         printf "    downloading toolchain archive.\n"
         wget -O gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2 -q --show-progress --progress=bar:force 2>&1 "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2?revision=05382cca-1721-44e1-ae19-1e7c3dc96118"
-    
+
     fi
 
     printf "    extracting toolchain archive.\n"
@@ -131,6 +131,7 @@ fi
 
 printf "    initializing toolchain.\n"
 export PATH=${PWD}/arm_toolchain_install/gcc-arm-none-eabi-9-2020-q2-update/bin:$PATH
+export QORC_TC_PATH=${PWD}/arm_toolchain_install/gcc-arm-none-eabi-9-2020-q2-update/bin
 
 
 ACTUAL_ARM_TOOLCHAIN_GCC_PATH=`which arm-none-eabi-gcc`
@@ -159,7 +160,7 @@ if [ ! -d $FPGA_TOOLCHAIN_INSTALL_DIR ]; then
 
         printf "    downloading toolchain installer.\n"
         wget -O $FPGA_TOOLCHAIN_INSTALLER  -q --show-progress --progress=bar:force 2>&1 https://github.com/QuickLogic-Corp/quicklogic-fpga-toolchain/releases/download/v1.3.1/Symbiflow_v1.3.1.gz.run
-    
+
     fi
 
     export INSTALL_DIR=$FPGA_TOOLCHAIN_INSTALL_DIR
@@ -238,42 +239,30 @@ printf "\n\nqorc-sdk env initialized.\n\n\n"
 # components : {
 
 #     qorc-sdk : {
-        
-#         download : true,
-#         install : true,
-#         timestamp : xxxxxx,
-#         version : yyyy
-        
-#     },
-    
-#     arm-gcc-toolchain : {
-        
-#         download : true,
-#         install : true,
-#         timestamp : xxxxxx,
-#         version : yyyy
-        
-#     },
-    
-#     quicklogic-fpga-toolchain : {
-        
-#         download : true,
-#         install : true,
-#         timestamp : xxxxxx,
-#         version : yyyy
-        
-#     },
-    
-#     quicklogic-tinyfpga-programmer : {
-        
-#         download : true,
-#         install : true,
-#         timestamp : xxxxxx,
-#         version : yyyy
-        
-#     }
 
-# }
+#         download : true,
+#         install : true,
+#         timestamp : xxxxxx,
+#         version : yyyy
+
+#     },
+
+#     arm-gcc-toolchain : {
+
+#         download : true,
+#         install : true,
+#         timestamp : xxxxxx,
+#         version : yyyy
+
+#     },
+
+#     quicklogic-fpga-toolchain : {
+
+#         download : true,
+#         install : true,
+#         timestamp : xxxxxx,
+#         version : yyyyendif #QORC_TC_PATH
+
 #---------------------------------------------------------
 
 # references for choices made while writing the sh script:

--- a/qf_apps/qf_advancedfpga/GCC_Project/Readme.txt
+++ b/qf_apps/qf_advancedfpga/GCC_Project/Readme.txt
@@ -1,12 +1,12 @@
-This is Readme.txt file for creating and building QuickAI Projects using 
-open-source GCC Tools and the provided Makefiles. 
+This is Readme.txt file for creating and building QuickAI Projects using
+open-source GCC Tools and the provided Makefiles.
 
 Requirements:
 
 The following open-source tools are needed in order to build using Makefiles.
 
 - ARM GCC toolchain available for download from
-    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/ 
+    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/
 - GNU Make program Version 3.81 available for download from
     - https://sourceforge.net/projects/gnuwin32/files/make/3.81
 
@@ -15,24 +15,24 @@ Overview:
 The following is a brief description of Makefile Architecture used for QuickAI SDK.
 
     There are 2 configuration setup files and a main Makefile under GCC_Project directory.
- 
+
     1. config.mk - selects the operating system environment to use, "Windows" or "Linux"
       -set BUILD_SYS=WINCMD - for Windows or comment it out for Linux
-      Note: 
+      Note:
         On Windows 10, there may be a problem to "auto-detect" the ARM Gnu Embedded Tool
-        Chain path. Then explicit set the TC_PATH to where the ARM GCC tools are installed.
+        Chain path. Then explicit set the QORC_TC_PATH to where the ARM GCC tools are installed.
       -
     2. config-GCC.mk - sets the GCC compiler options, source directories and "output file"
-    
-    3. Makefile - This is the main Makefile which calls the sub makefiles to build 
-    
+
+    3. Makefile - This is the main Makefile which calls the sub makefiles to build
+
        makefiles/ folder - There are separate makefiles for each directory that needs to be
             included in the given project. Each of the makefile starts with Makefile_ and ends
             with the Directory name (for example Makefile_HAL)
-       All the makefiles are exactly the same except for *_SRCS and *_DIR. 
+       All the makefiles are exactly the same except for *_SRCS and *_DIR.
         (The Makefile_Libraries is one of the exceptions and builds all the Libraries.)
-       
-       Makefile_common - is common to all the makefiles and "should not be changed". 
+
+       Makefile_common - is common to all the makefiles and "should not be changed".
 
     4. output/ folder - all the output is placed in this directory
              depend/ - all the depdencies created by the Make are placed in this folder
@@ -46,12 +46,12 @@ Adding New makefiles:
     - make a copy of one of the makefiles in the makefiles/ folder and rename it to
       reflect the name of the folder you want to include (for example Makefile_YourTest)
     - change the all *_DIR references to YOURTEST_DIR and *_SRCS to YOURTEST_SRCS
-    - in the main Makefile 
+    - in the main Makefile
        - add a new Target to the line starting with " $(OUTPUT_FILE).o: "
        - create build commands for the new Target as .PHONY objects point to your new makefile
 
 Building:
-     Make sure "C:\GnuWin32\bin" is the first in the Path and TC_PATH is properly set.
+     Make sure "C:\GnuWin32\bin" is the first in the Path and QORC_TC_PATH is properly set.
      - At the command prompt just type "make" to build all
      - Type "make clean" to delete all the object files and output built
      - type "make target" to selectively build a Target (for example, "make HAL")
@@ -59,4 +59,4 @@ Building:
 
    On a successfull build, output/bin will contain
      - *.bin, *.out, *.map files
-  
+

--- a/qf_apps/qf_advancedfpga/GCC_Project/config.mk
+++ b/qf_apps/qf_advancedfpga/GCC_Project/config.mk
@@ -103,21 +103,21 @@ FIND_TOOL_DIR := $(shell where /r c:\progra~2 arm-none-eabi-gcc)
 endif
 
 ifdef FIND_TOOL_DIR
-export TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
+export QORC_TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
 endif
 
 #Override with your own tool direcoty
-#export TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+#export QORC_TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
 
-export NM="$(TC_PATH)\arm-none-eabi-nm"
-export LD="$(TC_PATH)\arm-none-eabi-gcc"
-export AS="$(TC_PATH)\arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)\arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)\arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)\arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)\arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)\arm-none-eabi-objcopy"
 ################
 else
 ################ Linux ###################
@@ -143,29 +143,31 @@ TMPVAR = $(subst ${DIR_SEP}, ,${APP_DIR})
 PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell whereis arm-none-eabi-gcc))
-export TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+ifndef QORC_TC_PATH
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+endif #QORC_TC_PATH
 
 # Allow TOOL to be provided on the command line
-# ie;   make -f Makefile TC_PATH=/some/path/
+# ie;   make -f Makefile QORC_TC_PATH=/some/path/
 
-ifndef TC_PATH
+ifndef QORC_TC_PATH
 #Override with your own tool directory
 #use full path. do not use ~/ as a relative path
-#export TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
-#export TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
-export TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
+#export QORC_TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
+#export QORC_TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
+export QORC_TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
 endif
 
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
-export NM="$(TC_PATH)/arm-none-eabi-nm"
-export LD="$(TC_PATH)/arm-none-eabi-gcc"
-export AS="$(TC_PATH)/arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)/arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)/arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)/arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)/arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)/arm-none-eabi-objcopy"
 ################
 endif
 ################

--- a/qf_apps/qf_advancedfpga/GCC_Project/config.mk
+++ b/qf_apps/qf_advancedfpga/GCC_Project/config.mk
@@ -144,7 +144,7 @@ PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
 ifndef QORC_TC_PATH
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell which arm-none-eabi-gcc))
 export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
 endif #QORC_TC_PATH
 

--- a/qf_apps/qf_bootloader/GCC_Project/Readme.txt
+++ b/qf_apps/qf_bootloader/GCC_Project/Readme.txt
@@ -1,12 +1,12 @@
-This is Readme.txt file for creating and building QuickAI Projects using 
-open-source GCC Tools and the provided Makefiles. 
+This is Readme.txt file for creating and building QuickAI Projects using
+open-source GCC Tools and the provided Makefiles.
 
 Requirements:
 
 The following open-source tools are needed in order to build using Makefiles.
 
 - ARM GCC toolchain available for download from
-    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/ 
+    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/
 - GNU Make program Version 3.81 available for download from
     - https://sourceforge.net/projects/gnuwin32/files/make/3.81
 
@@ -16,24 +16,24 @@ Overview:
 The following is a brief description of Makefile Architecture used for QuickAI SDK.
 
     There are 2 configuration setup files and a main Makefile under GCC_Project directory.
- 
+
     1. config.mk - selects the operating system environment to use, "Windows" or "Linux"
       -set BUILD_SYS=WINCMD - for Windows or comment it out for Linux
-      Note: 
+      Note:
         On Windows 10, there may be a problem to "auto-detect" the ARM Gnu Embedded Tool
-        Chain path. Then explicit set the TC_PATH to where the ARM GCC tools are installed.
+        Chain path. Then explicit set the QORC_TC_PATH to where the ARM GCC tools are installed.
       -
     2. config-GCC.mk - sets the GCC compiler options, source directories and "output file"
-    
-    3. Makefile - This is the main Makefile which calls the sub makefiles to build 
-    
+
+    3. Makefile - This is the main Makefile which calls the sub makefiles to build
+
        makefiles/ folder - There are separate makefiles for each directory that needs to be
             included in the given project. Each of the makefile starts with Makefile_ and ends
             with the Directory name (for example Makefile_HAL)
-       All the makefiles are exactly the same except for *_SRCS and *_DIR. 
+       All the makefiles are exactly the same except for *_SRCS and *_DIR.
         (The Makefile_Libraries is one of the exceptions and builds all the Libraries.)
-       
-       Makefile_common - is common to all the makefiles and "should not be changed". 
+
+       Makefile_common - is common to all the makefiles and "should not be changed".
 
     4. output/ folder - all the output is placed in this directory
              depend/ - all the depdencies created by the Make are placed in this folder
@@ -47,12 +47,12 @@ Adding New makefiles:
     - make a copy of one of the makefiles in the makefiles/ folder and rename it to
       reflect the name of the folder you want to include (for example Makefile_YourTest)
     - change the all *_DIR references to YOURTEST_DIR and *_SRCS to YOURTEST_SRCS
-    - in the main Makefile 
+    - in the main Makefile
        - add a new Target to the line starting with " $(OUTPUT_FILE).o: "
        - create build commands for the new Target as .PHONY objects point to your new makefile
 
 Building:
-     Make sure "C:\GnuWin32\bin" is the first in the Path and TC_PATH is properly set.
+     Make sure "C:\GnuWin32\bin" is the first in the Path and QORC_TC_PATH is properly set.
      - At the command prompt just type "make" to build all
      - Type "make clean" to delete all the object files and output built
      - type "make target" to selectively build a Target (for example, "make HAL")
@@ -60,4 +60,4 @@ Building:
 
    On a successfull build, output/bin will contain
      - *.bin, *.out, *.map files
-  
+

--- a/qf_apps/qf_bootloader/GCC_Project/config.mk
+++ b/qf_apps/qf_bootloader/GCC_Project/config.mk
@@ -143,7 +143,7 @@ PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
 ifndef QORC_TC_PATH
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell which arm-none-eabi-gcc))
 export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
 endif #QORC_TC_PATH
 

--- a/qf_apps/qf_bootloader/GCC_Project/config.mk
+++ b/qf_apps/qf_bootloader/GCC_Project/config.mk
@@ -102,21 +102,21 @@ FIND_TOOL_DIR := $(shell where /r c:\progra~2 arm-none-eabi-gcc)
 endif
 
 ifdef FIND_TOOL_DIR
-export TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
+export QORC_TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
 endif
 
 #Override with your own tool direcoty
-#export TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+#export QORC_TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
 
-export NM="$(TC_PATH)\arm-none-eabi-nm"
-export LD="$(TC_PATH)\arm-none-eabi-gcc"
-export AS="$(TC_PATH)\arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)\arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)\arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)\arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)\arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)\arm-none-eabi-objcopy"
 ################
 else
 ################ Linux ###################
@@ -142,29 +142,31 @@ TMPVAR = $(subst ${DIR_SEP}, ,${APP_DIR})
 PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell whereis arm-none-eabi-gcc))
-export TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+ifndef QORC_TC_PATH
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+endif #QORC_TC_PATH
 
 # Allow TOOL to be provided on the command line
-# ie;   make -f Makefile TC_PATH=/some/path/
+# ie;   make -f Makefile QORC_TC_PATH=/some/path/
 
-ifndef TC_PATH
+ifndef QORC_TC_PATH
 #Override with your own tool directory
 #use full path. do not use ~/ as a relative path
-#export TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
-#export TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
-export TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
+#export QORC_TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
+#export QORC_TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
+export QORC_TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
 endif
 
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
-export NM="$(TC_PATH)/arm-none-eabi-nm"
-export LD="$(TC_PATH)/arm-none-eabi-gcc"
-export AS="$(TC_PATH)/arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)/arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)/arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)/arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)/arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)/arm-none-eabi-objcopy"
 ################
 endif
 ################

--- a/qf_apps/qf_bootloader_uart/GCC_Project/Readme.txt
+++ b/qf_apps/qf_bootloader_uart/GCC_Project/Readme.txt
@@ -1,12 +1,12 @@
-This is Readme.txt file for creating and building QuickAI Projects using 
-open-source GCC Tools and the provided Makefiles. 
+This is Readme.txt file for creating and building QuickAI Projects using
+open-source GCC Tools and the provided Makefiles.
 
 Requirements:
 
 The following open-source tools are needed in order to build using Makefiles.
 
 - ARM GCC toolchain available for download from
-    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/ 
+    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/
 - GNU Make program Version 3.81 available for download from
     - https://sourceforge.net/projects/gnuwin32/files/make/3.81
 
@@ -16,24 +16,24 @@ Overview:
 The following is a brief description of Makefile Architecture used for QuickAI SDK.
 
     There are 2 configuration setup files and a main Makefile under GCC_Project directory.
- 
+
     1. config.mk - selects the operating system environment to use, "Windows" or "Linux"
       -set BUILD_SYS=WINCMD - for Windows or comment it out for Linux
-      Note: 
+      Note:
         On Windows 10, there may be a problem to "auto-detect" the ARM Gnu Embedded Tool
-        Chain path. Then explicit set the TC_PATH to where the ARM GCC tools are installed.
+        Chain path. Then explicit set the QORC_TC_PATH to where the ARM GCC tools are installed.
       -
     2. config-GCC.mk - sets the GCC compiler options, source directories and "output file"
-    
-    3. Makefile - This is the main Makefile which calls the sub makefiles to build 
-    
+
+    3. Makefile - This is the main Makefile which calls the sub makefiles to build
+
        makefiles/ folder - There are separate makefiles for each directory that needs to be
             included in the given project. Each of the makefile starts with Makefile_ and ends
             with the Directory name (for example Makefile_HAL)
-       All the makefiles are exactly the same except for *_SRCS and *_DIR. 
+       All the makefiles are exactly the same except for *_SRCS and *_DIR.
         (The Makefile_Libraries is one of the exceptions and builds all the Libraries.)
-       
-       Makefile_common - is common to all the makefiles and "should not be changed". 
+
+       Makefile_common - is common to all the makefiles and "should not be changed".
 
     4. output/ folder - all the output is placed in this directory
              depend/ - all the depdencies created by the Make are placed in this folder
@@ -47,12 +47,12 @@ Adding New makefiles:
     - make a copy of one of the makefiles in the makefiles/ folder and rename it to
       reflect the name of the folder you want to include (for example Makefile_YourTest)
     - change the all *_DIR references to YOURTEST_DIR and *_SRCS to YOURTEST_SRCS
-    - in the main Makefile 
+    - in the main Makefile
        - add a new Target to the line starting with " $(OUTPUT_FILE).o: "
        - create build commands for the new Target as .PHONY objects point to your new makefile
 
 Building:
-     Make sure "C:\GnuWin32\bin" is the first in the Path and TC_PATH is properly set.
+     Make sure "C:\GnuWin32\bin" is the first in the Path and QORC_TC_PATH is properly set.
      - At the command prompt just type "make" to build all
      - Type "make clean" to delete all the object files and output built
      - type "make target" to selectively build a Target (for example, "make HAL")
@@ -60,4 +60,4 @@ Building:
 
    On a successfull build, output/bin will contain
      - *.bin, *.out, *.map files
-  
+

--- a/qf_apps/qf_bootloader_uart/GCC_Project/config.mk
+++ b/qf_apps/qf_bootloader_uart/GCC_Project/config.mk
@@ -143,7 +143,7 @@ PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
 ifndef QORC_TC_PATH
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell which arm-none-eabi-gcc))
 export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
 endif #QORC_TC_PATH
 

--- a/qf_apps/qf_bootloader_uart/GCC_Project/config.mk
+++ b/qf_apps/qf_bootloader_uart/GCC_Project/config.mk
@@ -102,21 +102,21 @@ FIND_TOOL_DIR := $(shell where /r c:\progra~2 arm-none-eabi-gcc)
 endif
 
 ifdef FIND_TOOL_DIR
-export TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
+export QORC_TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
 endif
 
 #Override with your own tool direcoty
-#export TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+#export QORC_TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
 
-export NM="$(TC_PATH)\arm-none-eabi-nm"
-export LD="$(TC_PATH)\arm-none-eabi-gcc"
-export AS="$(TC_PATH)\arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)\arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)\arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)\arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)\arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)\arm-none-eabi-objcopy"
 ################
 else
 ################ Linux ###################
@@ -142,29 +142,31 @@ TMPVAR = $(subst ${DIR_SEP}, ,${APP_DIR})
 PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell whereis arm-none-eabi-gcc))
-export TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+ifndef QORC_TC_PATH
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+endif #QORC_TC_PATH
 
 # Allow TOOL to be provided on the command line
-# ie;   make -f Makefile TC_PATH=/some/path/
+# ie;   make -f Makefile QORC_TC_PATH=/some/path/
 
-ifndef TC_PATH
+ifndef QORC_TC_PATH
 #Override with your own tool directory
 #use full path. do not use ~/ as a relative path
-#export TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
-#export TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
-export TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
+#export QORC_TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
+#export QORC_TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
+export QORC_TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
 endif
 
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
-export NM="$(TC_PATH)/arm-none-eabi-nm"
-export LD="$(TC_PATH)/arm-none-eabi-gcc"
-export AS="$(TC_PATH)/arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)/arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)/arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)/arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)/arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)/arm-none-eabi-objcopy"
 ################
 endif
 ################

--- a/qf_apps/qf_fpgauart_app/GCC_Project/Readme.txt
+++ b/qf_apps/qf_fpgauart_app/GCC_Project/Readme.txt
@@ -1,12 +1,12 @@
-This is Readme.txt file for creating and building QuickAI Projects using 
-open-source GCC Tools and the provided Makefiles. 
+This is Readme.txt file for creating and building QuickAI Projects using
+open-source GCC Tools and the provided Makefiles.
 
 Requirements:
 
 The following open-source tools are needed in order to build using Makefiles.
 
 - ARM GCC toolchain available for download from
-    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/ 
+    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/
 - GNU Make program Version 3.81 available for download from
     - https://sourceforge.net/projects/gnuwin32/files/make/3.81
 
@@ -15,24 +15,24 @@ Overview:
 The following is a brief description of Makefile Architecture used for QuickAI SDK.
 
     There are 2 configuration setup files and a main Makefile under GCC_Project directory.
- 
+
     1. config.mk - selects the operating system environment to use, "Windows" or "Linux"
       -set BUILD_SYS=WINCMD - for Windows or comment it out for Linux
-      Note: 
+      Note:
         On Windows 10, there may be a problem to "auto-detect" the ARM Gnu Embedded Tool
-        Chain path. Then explicit set the TC_PATH to where the ARM GCC tools are installed.
+        Chain path. Then explicit set the QORC_TC_PATH to where the ARM GCC tools are installed.
       -
     2. config-GCC.mk - sets the GCC compiler options, source directories and "output file"
-    
-    3. Makefile - This is the main Makefile which calls the sub makefiles to build 
-    
+
+    3. Makefile - This is the main Makefile which calls the sub makefiles to build
+
        makefiles/ folder - There are separate makefiles for each directory that needs to be
             included in the given project. Each of the makefile starts with Makefile_ and ends
             with the Directory name (for example Makefile_HAL)
-       All the makefiles are exactly the same except for *_SRCS and *_DIR. 
+       All the makefiles are exactly the same except for *_SRCS and *_DIR.
         (The Makefile_Libraries is one of the exceptions and builds all the Libraries.)
-       
-       Makefile_common - is common to all the makefiles and "should not be changed". 
+
+       Makefile_common - is common to all the makefiles and "should not be changed".
 
     4. output/ folder - all the output is placed in this directory
              depend/ - all the depdencies created by the Make are placed in this folder
@@ -46,12 +46,12 @@ Adding New makefiles:
     - make a copy of one of the makefiles in the makefiles/ folder and rename it to
       reflect the name of the folder you want to include (for example Makefile_YourTest)
     - change the all *_DIR references to YOURTEST_DIR and *_SRCS to YOURTEST_SRCS
-    - in the main Makefile 
+    - in the main Makefile
        - add a new Target to the line starting with " $(OUTPUT_FILE).o: "
        - create build commands for the new Target as .PHONY objects point to your new makefile
 
 Building:
-     Make sure "C:\GnuWin32\bin" is the first in the Path and TC_PATH is properly set.
+     Make sure "C:\GnuWin32\bin" is the first in the Path and QORC_TC_PATH is properly set.
      - At the command prompt just type "make" to build all
      - Type "make clean" to delete all the object files and output built
      - type "make target" to selectively build a Target (for example, "make HAL")
@@ -59,4 +59,4 @@ Building:
 
    On a successfull build, output/bin will contain
      - *.bin, *.out, *.map files
-  
+

--- a/qf_apps/qf_fpgauart_app/GCC_Project/config.mk
+++ b/qf_apps/qf_fpgauart_app/GCC_Project/config.mk
@@ -103,21 +103,21 @@ FIND_TOOL_DIR := $(shell where /r c:\progra~2 arm-none-eabi-gcc)
 endif
 
 ifdef FIND_TOOL_DIR
-export TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
+export QORC_TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
 endif
 
 #Override with your own tool direcoty
-#export TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+#export QORC_TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
 
-export NM="$(TC_PATH)\arm-none-eabi-nm"
-export LD="$(TC_PATH)\arm-none-eabi-gcc"
-export AS="$(TC_PATH)\arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)\arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)\arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)\arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)\arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)\arm-none-eabi-objcopy"
 ################
 else
 ################ Linux ###################
@@ -143,29 +143,31 @@ TMPVAR = $(subst ${DIR_SEP}, ,${APP_DIR})
 PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell whereis arm-none-eabi-gcc))
-export TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+ifndef QORC_TC_PATH
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+endif #QORC_TC_PATH
 
 # Allow TOOL to be provided on the command line
-# ie;   make -f Makefile TC_PATH=/some/path/
+# ie;   make -f Makefile QORC_TC_PATH=/some/path/
 
-ifndef TC_PATH
+ifndef QORC_TC_PATH
 #Override with your own tool directory
 #use full path. do not use ~/ as a relative path
-#export TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
-#export TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
-export TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
+#export QORC_TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
+#export QORC_TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
+export QORC_TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
 endif
 
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
-export NM="$(TC_PATH)/arm-none-eabi-nm"
-export LD="$(TC_PATH)/arm-none-eabi-gcc"
-export AS="$(TC_PATH)/arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)/arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)/arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)/arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)/arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)/arm-none-eabi-objcopy"
 ################
 endif
 ################

--- a/qf_apps/qf_fpgauart_app/GCC_Project/config.mk
+++ b/qf_apps/qf_fpgauart_app/GCC_Project/config.mk
@@ -144,7 +144,7 @@ PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
 ifndef QORC_TC_PATH
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell which arm-none-eabi-gcc))
 export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
 endif #QORC_TC_PATH
 

--- a/qf_apps/qf_gwtestharness/GCC_Project/Readme.txt
+++ b/qf_apps/qf_gwtestharness/GCC_Project/Readme.txt
@@ -1,12 +1,12 @@
-This is Readme.txt file for creating and building QuickAI Projects using 
-open-source GCC Tools and the provided Makefiles. 
+This is Readme.txt file for creating and building QuickAI Projects using
+open-source GCC Tools and the provided Makefiles.
 
 Requirements:
 
 The following open-source tools are needed in order to build using Makefiles.
 
 - ARM GCC toolchain available for download from
-    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/ 
+    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/
 - GNU Make program Version 3.81 available for download from
     - https://sourceforge.net/projects/gnuwin32/files/make/3.81
 
@@ -15,24 +15,24 @@ Overview:
 The following is a brief description of Makefile Architecture used for QuickAI SDK.
 
     There are 2 configuration setup files and a main Makefile under GCC_Project directory.
- 
+
     1. config.mk - selects the operating system environment to use, "Windows" or "Linux"
       -set BUILD_SYS=WINCMD - for Windows or comment it out for Linux
-      Note: 
+      Note:
         On Windows 10, there may be a problem to "auto-detect" the ARM Gnu Embedded Tool
-        Chain path. Then explicit set the TC_PATH to where the ARM GCC tools are installed.
+        Chain path. Then explicit set the QORC_TC_PATH to where the ARM GCC tools are installed.
       -
     2. config-GCC.mk - sets the GCC compiler options, source directories and "output file"
-    
-    3. Makefile - This is the main Makefile which calls the sub makefiles to build 
-    
+
+    3. Makefile - This is the main Makefile which calls the sub makefiles to build
+
        makefiles/ folder - There are separate makefiles for each directory that needs to be
             included in the given project. Each of the makefile starts with Makefile_ and ends
             with the Directory name (for example Makefile_HAL)
-       All the makefiles are exactly the same except for *_SRCS and *_DIR. 
+       All the makefiles are exactly the same except for *_SRCS and *_DIR.
         (The Makefile_Libraries is one of the exceptions and builds all the Libraries.)
-       
-       Makefile_common - is common to all the makefiles and "should not be changed". 
+
+       Makefile_common - is common to all the makefiles and "should not be changed".
 
     4. output/ folder - all the output is placed in this directory
              depend/ - all the depdencies created by the Make are placed in this folder
@@ -46,12 +46,12 @@ Adding New makefiles:
     - make a copy of one of the makefiles in the makefiles/ folder and rename it to
       reflect the name of the folder you want to include (for example Makefile_YourTest)
     - change the all *_DIR references to YOURTEST_DIR and *_SRCS to YOURTEST_SRCS
-    - in the main Makefile 
+    - in the main Makefile
        - add a new Target to the line starting with " $(OUTPUT_FILE).o: "
        - create build commands for the new Target as .PHONY objects point to your new makefile
 
 Building:
-     Make sure "C:\GnuWin32\bin" is the first in the Path and TC_PATH is properly set.
+     Make sure "C:\GnuWin32\bin" is the first in the Path and QORC_TC_PATH is properly set.
      - At the command prompt just type "make" to build all
      - Type "make clean" to delete all the object files and output built
      - type "make target" to selectively build a Target (for example, "make HAL")
@@ -59,4 +59,4 @@ Building:
 
    On a successfull build, output/bin will contain
      - *.bin, *.out, *.map files
-  
+

--- a/qf_apps/qf_gwtestharness/GCC_Project/config.mk
+++ b/qf_apps/qf_gwtestharness/GCC_Project/config.mk
@@ -143,7 +143,7 @@ PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
 ifndef QORC_TC_PATH
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell which arm-none-eabi-gcc))
 export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
 endif #QORC_TC_PATH
 

--- a/qf_apps/qf_gwtestharness/GCC_Project/config.mk
+++ b/qf_apps/qf_gwtestharness/GCC_Project/config.mk
@@ -102,21 +102,21 @@ FIND_TOOL_DIR := $(shell where /r c:\progra~2 arm-none-eabi-gcc)
 endif
 
 ifdef FIND_TOOL_DIR
-export TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
+export QORC_TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
 endif
 
 #Override with your own tool direcoty
-#export TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+#export QORC_TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
 
-export NM="$(TC_PATH)\arm-none-eabi-nm"
-export LD="$(TC_PATH)\arm-none-eabi-gcc"
-export AS="$(TC_PATH)\arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)\arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)\arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)\arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)\arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)\arm-none-eabi-objcopy"
 ################
 else
 ################ Linux ###################
@@ -142,29 +142,31 @@ TMPVAR = $(subst ${DIR_SEP}, ,${APP_DIR})
 PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell whereis arm-none-eabi-gcc))
-export TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+ifndef QORC_TC_PATH
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+endif #QORC_TC_PATH
 
 # Allow TOOL to be provided on the command line
-# ie;   make -f Makefile TC_PATH=/some/path/
+# ie;   make -f Makefile QORC_TC_PATH=/some/path/
 
-ifndef TC_PATH
+ifndef QORC_TC_PATH
 #Override with your own tool directory
 #use full path. do not use ~/ as a relative path
-#export TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
-#export TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
-export TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
+#export QORC_TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
+#export QORC_TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
+export QORC_TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
 endif
 
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
-export NM="$(TC_PATH)/arm-none-eabi-nm"
-export LD="$(TC_PATH)/arm-none-eabi-gcc"
-export AS="$(TC_PATH)/arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)/arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)/arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)/arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)/arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)/arm-none-eabi-objcopy"
 ################
 endif
 ################

--- a/qf_apps/qf_helloworldhw/GCC_Project/Readme.txt
+++ b/qf_apps/qf_helloworldhw/GCC_Project/Readme.txt
@@ -1,12 +1,12 @@
-This is Readme.txt file for creating and building QuickAI Projects using 
-open-source GCC Tools and the provided Makefiles. 
+This is Readme.txt file for creating and building QuickAI Projects using
+open-source GCC Tools and the provided Makefiles.
 
 Requirements:
 
 The following open-source tools are needed in order to build using Makefiles.
 
 - ARM GCC toolchain available for download from
-    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/ 
+    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/
 - GNU Make program Version 3.81 available for download from
     - https://sourceforge.net/projects/gnuwin32/files/make/3.81
 
@@ -15,24 +15,24 @@ Overview:
 The following is a brief description of Makefile Architecture used for QuickAI SDK.
 
     There are 2 configuration setup files and a main Makefile under GCC_Project directory.
- 
+
     1. config.mk - selects the operating system environment to use, "Windows" or "Linux"
       -set BUILD_SYS=WINCMD - for Windows or comment it out for Linux
-      Note: 
+      Note:
         On Windows 10, there may be a problem to "auto-detect" the ARM Gnu Embedded Tool
-        Chain path. Then explicit set the TC_PATH to where the ARM GCC tools are installed.
+        Chain path. Then explicit set the QORC_TC_PATH to where the ARM GCC tools are installed.
       -
     2. config-GCC.mk - sets the GCC compiler options, source directories and "output file"
-    
-    3. Makefile - This is the main Makefile which calls the sub makefiles to build 
-    
+
+    3. Makefile - This is the main Makefile which calls the sub makefiles to build
+
        makefiles/ folder - There are separate makefiles for each directory that needs to be
             included in the given project. Each of the makefile starts with Makefile_ and ends
             with the Directory name (for example Makefile_HAL)
-       All the makefiles are exactly the same except for *_SRCS and *_DIR. 
+       All the makefiles are exactly the same except for *_SRCS and *_DIR.
         (The Makefile_Libraries is one of the exceptions and builds all the Libraries.)
-       
-       Makefile_common - is common to all the makefiles and "should not be changed". 
+
+       Makefile_common - is common to all the makefiles and "should not be changed".
 
     4. output/ folder - all the output is placed in this directory
              depend/ - all the depdencies created by the Make are placed in this folder
@@ -46,12 +46,12 @@ Adding New makefiles:
     - make a copy of one of the makefiles in the makefiles/ folder and rename it to
       reflect the name of the folder you want to include (for example Makefile_YourTest)
     - change the all *_DIR references to YOURTEST_DIR and *_SRCS to YOURTEST_SRCS
-    - in the main Makefile 
+    - in the main Makefile
        - add a new Target to the line starting with " $(OUTPUT_FILE).o: "
        - create build commands for the new Target as .PHONY objects point to your new makefile
 
 Building:
-     Make sure "C:\GnuWin32\bin" is the first in the Path and TC_PATH is properly set.
+     Make sure "C:\GnuWin32\bin" is the first in the Path and QORC_TC_PATH is properly set.
      - At the command prompt just type "make" to build all
      - Type "make clean" to delete all the object files and output built
      - type "make target" to selectively build a Target (for example, "make HAL")
@@ -59,4 +59,4 @@ Building:
 
    On a successfull build, output/bin will contain
      - *.bin, *.out, *.map files
-  
+

--- a/qf_apps/qf_helloworldhw/GCC_Project/config.mk
+++ b/qf_apps/qf_helloworldhw/GCC_Project/config.mk
@@ -103,21 +103,21 @@ FIND_TOOL_DIR := $(shell where /r c:\progra~2 arm-none-eabi-gcc)
 endif
 
 ifdef FIND_TOOL_DIR
-export TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
+export QORC_TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
 endif
 
 #Override with your own tool direcoty
-#export TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+#export QORC_TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
 
-export NM="$(TC_PATH)\arm-none-eabi-nm"
-export LD="$(TC_PATH)\arm-none-eabi-gcc"
-export AS="$(TC_PATH)\arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)\arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)\arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)\arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)\arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)\arm-none-eabi-objcopy"
 ################
 else
 ################ Linux ###################
@@ -143,29 +143,31 @@ TMPVAR = $(subst ${DIR_SEP}, ,${APP_DIR})
 PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell whereis arm-none-eabi-gcc))
-export TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+ifndef QORC_TC_PATH
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+endif #QORC_TC_PATH
 
 # Allow TOOL to be provided on the command line
-# ie;   make -f Makefile TC_PATH=/some/path/
+# ie;   make -f Makefile QORC_TC_PATH=/some/path/
 
-ifndef TC_PATH
+ifndef QORC_TC_PATH
 #Override with your own tool directory
 #use full path. do not use ~/ as a relative path
-#export TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
-#export TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
-export TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
+#export QORC_TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
+#export QORC_TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
+export QORC_TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
 endif
 
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
-export NM="$(TC_PATH)/arm-none-eabi-nm"
-export LD="$(TC_PATH)/arm-none-eabi-gcc"
-export AS="$(TC_PATH)/arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)/arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)/arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)/arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)/arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)/arm-none-eabi-objcopy"
 ################
 endif
 ################

--- a/qf_apps/qf_helloworldhw/GCC_Project/config.mk
+++ b/qf_apps/qf_helloworldhw/GCC_Project/config.mk
@@ -144,7 +144,7 @@ PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
 ifndef QORC_TC_PATH
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell which arm-none-eabi-gcc))
 export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
 endif #QORC_TC_PATH
 

--- a/qf_apps/qf_helloworldsw/GCC_Project/Readme.txt
+++ b/qf_apps/qf_helloworldsw/GCC_Project/Readme.txt
@@ -1,12 +1,12 @@
-This is Readme.txt file for creating and building QuickAI Projects using 
-open-source GCC Tools and the provided Makefiles. 
+This is Readme.txt file for creating and building QuickAI Projects using
+open-source GCC Tools and the provided Makefiles.
 
 Requirements:
 
 The following open-source tools are needed in order to build using Makefiles.
 
 - ARM GCC toolchain available for download from
-    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/ 
+    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/
 - GNU Make program Version 3.81 available for download from
     - https://sourceforge.net/projects/gnuwin32/files/make/3.81
 
@@ -15,24 +15,24 @@ Overview:
 The following is a brief description of Makefile Architecture used for QuickAI SDK.
 
     There are 2 configuration setup files and a main Makefile under GCC_Project directory.
- 
+
     1. config.mk - selects the operating system environment to use, "Windows" or "Linux"
       -set BUILD_SYS=WINCMD - for Windows or comment it out for Linux
-      Note: 
+      Note:
         On Windows 10, there may be a problem to "auto-detect" the ARM Gnu Embedded Tool
-        Chain path. Then explicit set the TC_PATH to where the ARM GCC tools are installed.
+        Chain path. Then explicit set the QORC_TC_PATH to where the ARM GCC tools are installed.
       -
     2. config-GCC.mk - sets the GCC compiler options, source directories and "output file"
-    
-    3. Makefile - This is the main Makefile which calls the sub makefiles to build 
-    
+
+    3. Makefile - This is the main Makefile which calls the sub makefiles to build
+
        makefiles/ folder - There are separate makefiles for each directory that needs to be
             included in the given project. Each of the makefile starts with Makefile_ and ends
             with the Directory name (for example Makefile_HAL)
-       All the makefiles are exactly the same except for *_SRCS and *_DIR. 
+       All the makefiles are exactly the same except for *_SRCS and *_DIR.
         (The Makefile_Libraries is one of the exceptions and builds all the Libraries.)
-       
-       Makefile_common - is common to all the makefiles and "should not be changed". 
+
+       Makefile_common - is common to all the makefiles and "should not be changed".
 
     4. output/ folder - all the output is placed in this directory
              depend/ - all the depdencies created by the Make are placed in this folder
@@ -46,12 +46,12 @@ Adding New makefiles:
     - make a copy of one of the makefiles in the makefiles/ folder and rename it to
       reflect the name of the folder you want to include (for example Makefile_YourTest)
     - change the all *_DIR references to YOURTEST_DIR and *_SRCS to YOURTEST_SRCS
-    - in the main Makefile 
+    - in the main Makefile
        - add a new Target to the line starting with " $(OUTPUT_FILE).o: "
        - create build commands for the new Target as .PHONY objects point to your new makefile
 
 Building:
-     Make sure "C:\GnuWin32\bin" is the first in the Path and TC_PATH is properly set.
+     Make sure "C:\GnuWin32\bin" is the first in the Path and QORC_TC_PATH is properly set.
      - At the command prompt just type "make" to build all
      - Type "make clean" to delete all the object files and output built
      - type "make target" to selectively build a Target (for example, "make HAL")
@@ -59,4 +59,4 @@ Building:
 
    On a successfull build, output/bin will contain
      - *.bin, *.out, *.map files
-  
+

--- a/qf_apps/qf_helloworldsw/GCC_Project/config.mk
+++ b/qf_apps/qf_helloworldsw/GCC_Project/config.mk
@@ -103,21 +103,21 @@ FIND_TOOL_DIR := $(shell where /r c:\progra~2 arm-none-eabi-gcc)
 endif
 
 ifdef FIND_TOOL_DIR
-export TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
+export QORC_TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
 endif
 
 #Override with your own tool direcoty
-#export TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+#export QORC_TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
 
-export NM="$(TC_PATH)\arm-none-eabi-nm"
-export LD="$(TC_PATH)\arm-none-eabi-gcc"
-export AS="$(TC_PATH)\arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)\arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)\arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)\arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)\arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)\arm-none-eabi-objcopy"
 ################
 else
 ################ Linux ###################
@@ -143,29 +143,31 @@ TMPVAR = $(subst ${DIR_SEP}, ,${APP_DIR})
 PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell whereis arm-none-eabi-gcc))
-export TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+ifndef QORC_TC_PATH
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+endif #QORC_TC_PATH
 
 # Allow TOOL to be provided on the command line
-# ie;   make -f Makefile TC_PATH=/some/path/
+# ie;   make -f Makefile QORC_TC_PATH=/some/path/
 
-ifndef TC_PATH
+ifndef QORC_TC_PATH
 #Override with your own tool directory
 #use full path. do not use ~/ as a relative path
-#export TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
-#export TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
-export TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
+#export QORC_TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
+#export QORC_TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
+export QORC_TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
 endif
 
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
-export NM="$(TC_PATH)/arm-none-eabi-nm"
-export LD="$(TC_PATH)/arm-none-eabi-gcc"
-export AS="$(TC_PATH)/arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)/arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)/arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)/arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)/arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)/arm-none-eabi-objcopy"
 ################
 endif
 ################

--- a/qf_apps/qf_helloworldsw/GCC_Project/config.mk
+++ b/qf_apps/qf_helloworldsw/GCC_Project/config.mk
@@ -144,7 +144,7 @@ PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
 ifndef QORC_TC_PATH
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell which arm-none-eabi-gcc))
 export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
 endif #QORC_TC_PATH
 

--- a/qf_apps/qf_loadflash/GCC_Project/Readme.txt
+++ b/qf_apps/qf_loadflash/GCC_Project/Readme.txt
@@ -1,12 +1,12 @@
-This is Readme.txt file for creating and building QuickAI Projects using 
-open-source GCC Tools and the provided Makefiles. 
+This is Readme.txt file for creating and building QuickAI Projects using
+open-source GCC Tools and the provided Makefiles.
 
 Requirements:
 
 The following open-source tools are needed in order to build using Makefiles.
 
 - ARM GCC toolchain available for download from
-    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/ 
+    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/
 - GNU Make program Version 3.81 available for download from
     - https://sourceforge.net/projects/gnuwin32/files/make/3.81
 
@@ -15,24 +15,24 @@ Overview:
 The following is a brief description of Makefile Architecture used for QuickAI SDK.
 
     There are 2 configuration setup files and a main Makefile under GCC_Project directory.
- 
+
     1. config.mk - selects the operating system environment to use, "Windows" or "Linux"
       -set BUILD_SYS=WINCMD - for Windows or comment it out for Linux
-      Note: 
+      Note:
         On Windows 10, there may be a problem to "auto-detect" the ARM Gnu Embedded Tool
-        Chain path. Then explicit set the TC_PATH to where the ARM GCC tools are installed.
+        Chain path. Then explicit set the QORC_TC_PATH to where the ARM GCC tools are installed.
       -
     2. config-GCC.mk - sets the GCC compiler options, source directories and "output file"
-    
-    3. Makefile - This is the main Makefile which calls the sub makefiles to build 
-    
+
+    3. Makefile - This is the main Makefile which calls the sub makefiles to build
+
        makefiles/ folder - There are separate makefiles for each directory that needs to be
             included in the given project. Each of the makefile starts with Makefile_ and ends
             with the Directory name (for example Makefile_HAL)
-       All the makefiles are exactly the same except for *_SRCS and *_DIR. 
+       All the makefiles are exactly the same except for *_SRCS and *_DIR.
         (The Makefile_Libraries is one of the exceptions and builds all the Libraries.)
-       
-       Makefile_common - is common to all the makefiles and "should not be changed". 
+
+       Makefile_common - is common to all the makefiles and "should not be changed".
 
     4. output/ folder - all the output is placed in this directory
              depend/ - all the depdencies created by the Make are placed in this folder
@@ -46,12 +46,12 @@ Adding New makefiles:
     - make a copy of one of the makefiles in the makefiles/ folder and rename it to
       reflect the name of the folder you want to include (for example Makefile_YourTest)
     - change the all *_DIR references to YOURTEST_DIR and *_SRCS to YOURTEST_SRCS
-    - in the main Makefile 
+    - in the main Makefile
        - add a new Target to the line starting with " $(OUTPUT_FILE).o: "
        - create build commands for the new Target as .PHONY objects point to your new makefile
 
 Building:
-     Make sure "C:\GnuWin32\bin" is the first in the Path and TC_PATH is properly set.
+     Make sure "C:\GnuWin32\bin" is the first in the Path and QORC_TC_PATH is properly set.
      - At the command prompt just type "make" to build all
      - Type "make clean" to delete all the object files and output built
      - type "make target" to selectively build a Target (for example, "make HAL")
@@ -59,4 +59,4 @@ Building:
 
    On a successfull build, output/bin will contain
      - *.bin, *.out, *.map files
-  
+

--- a/qf_apps/qf_loadflash/GCC_Project/config.mk
+++ b/qf_apps/qf_loadflash/GCC_Project/config.mk
@@ -103,21 +103,21 @@ FIND_TOOL_DIR := $(shell where /r c:\progra~2 arm-none-eabi-gcc)
 endif
 
 ifdef FIND_TOOL_DIR
-export TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
+export QORC_TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
 endif
 
 #Override with your own tool direcoty
-#export TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+#export QORC_TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
 
-export NM="$(TC_PATH)\arm-none-eabi-nm"
-export LD="$(TC_PATH)\arm-none-eabi-gcc"
-export AS="$(TC_PATH)\arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)\arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)\arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)\arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)\arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)\arm-none-eabi-objcopy"
 ################
 else
 ################ Linux ###################
@@ -143,29 +143,31 @@ TMPVAR = $(subst ${DIR_SEP}, ,${APP_DIR})
 PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell whereis arm-none-eabi-gcc))
-export TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+ifndef QORC_TC_PATH
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+endif #QORC_TC_PATH
 
 # Allow TOOL to be provided on the command line
-# ie;   make -f Makefile TC_PATH=/some/path/
+# ie;   make -f Makefile QORC_TC_PATH=/some/path/
 
-ifndef TC_PATH
+ifndef QORC_TC_PATH
 #Override with your own tool directory
 #use full path. do not use ~/ as a relative path
-#export TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
-#export TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
-export TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
+#export QORC_TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
+#export QORC_TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
+export QORC_TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
 endif
 
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
-export NM="$(TC_PATH)/arm-none-eabi-nm"
-export LD="$(TC_PATH)/arm-none-eabi-gcc"
-export AS="$(TC_PATH)/arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)/arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)/arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)/arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)/arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)/arm-none-eabi-objcopy"
 ################
 endif
 ################

--- a/qf_apps/qf_loadflash/GCC_Project/config.mk
+++ b/qf_apps/qf_loadflash/GCC_Project/config.mk
@@ -144,7 +144,7 @@ PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
 ifndef QORC_TC_PATH
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell which arm-none-eabi-gcc))
 export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
 endif #QORC_TC_PATH
 

--- a/qf_apps/qf_loadflash_uart/GCC_Project/Readme.txt
+++ b/qf_apps/qf_loadflash_uart/GCC_Project/Readme.txt
@@ -1,12 +1,12 @@
-This is Readme.txt file for creating and building QuickAI Projects using 
-open-source GCC Tools and the provided Makefiles. 
+This is Readme.txt file for creating and building QuickAI Projects using
+open-source GCC Tools and the provided Makefiles.
 
 Requirements:
 
 The following open-source tools are needed in order to build using Makefiles.
 
 - ARM GCC toolchain available for download from
-    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/ 
+    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/
 - GNU Make program Version 3.81 available for download from
     - https://sourceforge.net/projects/gnuwin32/files/make/3.81
 
@@ -15,24 +15,24 @@ Overview:
 The following is a brief description of Makefile Architecture used for QuickAI SDK.
 
     There are 2 configuration setup files and a main Makefile under GCC_Project directory.
- 
+
     1. config.mk - selects the operating system environment to use, "Windows" or "Linux"
       -set BUILD_SYS=WINCMD - for Windows or comment it out for Linux
-      Note: 
+      Note:
         On Windows 10, there may be a problem to "auto-detect" the ARM Gnu Embedded Tool
-        Chain path. Then explicit set the TC_PATH to where the ARM GCC tools are installed.
+        Chain path. Then explicit set the QORC_TC_PATH to where the ARM GCC tools are installed.
       -
     2. config-GCC.mk - sets the GCC compiler options, source directories and "output file"
-    
-    3. Makefile - This is the main Makefile which calls the sub makefiles to build 
-    
+
+    3. Makefile - This is the main Makefile which calls the sub makefiles to build
+
        makefiles/ folder - There are separate makefiles for each directory that needs to be
             included in the given project. Each of the makefile starts with Makefile_ and ends
             with the Directory name (for example Makefile_HAL)
-       All the makefiles are exactly the same except for *_SRCS and *_DIR. 
+       All the makefiles are exactly the same except for *_SRCS and *_DIR.
         (The Makefile_Libraries is one of the exceptions and builds all the Libraries.)
-       
-       Makefile_common - is common to all the makefiles and "should not be changed". 
+
+       Makefile_common - is common to all the makefiles and "should not be changed".
 
     4. output/ folder - all the output is placed in this directory
              depend/ - all the depdencies created by the Make are placed in this folder
@@ -46,12 +46,12 @@ Adding New makefiles:
     - make a copy of one of the makefiles in the makefiles/ folder and rename it to
       reflect the name of the folder you want to include (for example Makefile_YourTest)
     - change the all *_DIR references to YOURTEST_DIR and *_SRCS to YOURTEST_SRCS
-    - in the main Makefile 
+    - in the main Makefile
        - add a new Target to the line starting with " $(OUTPUT_FILE).o: "
        - create build commands for the new Target as .PHONY objects point to your new makefile
 
 Building:
-     Make sure "C:\GnuWin32\bin" is the first in the Path and TC_PATH is properly set.
+     Make sure "C:\GnuWin32\bin" is the first in the Path and QORC_TC_PATH is properly set.
      - At the command prompt just type "make" to build all
      - Type "make clean" to delete all the object files and output built
      - type "make target" to selectively build a Target (for example, "make HAL")
@@ -59,4 +59,4 @@ Building:
 
    On a successfull build, output/bin will contain
      - *.bin, *.out, *.map files
-  
+

--- a/qf_apps/qf_loadflash_uart/GCC_Project/config.mk
+++ b/qf_apps/qf_loadflash_uart/GCC_Project/config.mk
@@ -103,21 +103,21 @@ FIND_TOOL_DIR := $(shell where /r c:\progra~2 arm-none-eabi-gcc)
 endif
 
 ifdef FIND_TOOL_DIR
-export TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
+export QORC_TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
 endif
 
 #Override with your own tool direcoty
-#export TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+#export QORC_TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
 
-export NM="$(TC_PATH)\arm-none-eabi-nm"
-export LD="$(TC_PATH)\arm-none-eabi-gcc"
-export AS="$(TC_PATH)\arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)\arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)\arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)\arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)\arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)\arm-none-eabi-objcopy"
 ################
 else
 ################ Linux ###################
@@ -143,29 +143,31 @@ TMPVAR = $(subst ${DIR_SEP}, ,${APP_DIR})
 PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell whereis arm-none-eabi-gcc))
-export TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+ifndef QORC_TC_PATH
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+endif #QORC_TC_PATH
 
 # Allow TOOL to be provided on the command line
-# ie;   make -f Makefile TC_PATH=/some/path/
+# ie;   make -f Makefile QORC_TC_PATH=/some/path/
 
-ifndef TC_PATH
+ifndef QORC_TC_PATH
 #Override with your own tool directory
 #use full path. do not use ~/ as a relative path
-#export TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
-#export TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
-export TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
+#export QORC_TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
+#export QORC_TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
+export QORC_TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
 endif
 
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
-export NM="$(TC_PATH)/arm-none-eabi-nm"
-export LD="$(TC_PATH)/arm-none-eabi-gcc"
-export AS="$(TC_PATH)/arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)/arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)/arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)/arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)/arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)/arm-none-eabi-objcopy"
 ################
 endif
 ################

--- a/qf_apps/qf_loadflash_uart/GCC_Project/config.mk
+++ b/qf_apps/qf_loadflash_uart/GCC_Project/config.mk
@@ -144,7 +144,7 @@ PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
 ifndef QORC_TC_PATH
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell which arm-none-eabi-gcc))
 export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
 endif #QORC_TC_PATH
 

--- a/qf_apps/qf_mqttsn_ai_app/GCC_Project/Readme.txt
+++ b/qf_apps/qf_mqttsn_ai_app/GCC_Project/Readme.txt
@@ -1,12 +1,12 @@
-This is Readme.txt file for creating and building QuickAI Projects using 
-open-source GCC Tools and the provided Makefiles. 
+This is Readme.txt file for creating and building QuickAI Projects using
+open-source GCC Tools and the provided Makefiles.
 
 Requirements:
 
 The following open-source tools are needed in order to build using Makefiles.
 
 - ARM GCC toolchain available for download from
-    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/ 
+    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/
 - GNU Make program Version 3.81 available for download from
     - https://sourceforge.net/projects/gnuwin32/files/make/3.81
 
@@ -15,24 +15,24 @@ Overview:
 The following is a brief description of Makefile Architecture used for QuickAI SDK.
 
     There are 2 configuration setup files and a main Makefile under GCC_Project directory.
- 
+
     1. config.mk - selects the operating system environment to use, "Windows" or "Linux"
       -set BUILD_SYS=WINCMD - for Windows or comment it out for Linux
-      Note: 
+      Note:
         On Windows 10, there may be a problem to "auto-detect" the ARM Gnu Embedded Tool
-        Chain path. Then explicit set the TC_PATH to where the ARM GCC tools are installed.
+        Chain path. Then explicit set the QORC_TC_PATH to where the ARM GCC tools are installed.
       -
     2. config-GCC.mk - sets the GCC compiler options, source directories and "output file"
-    
-    3. Makefile - This is the main Makefile which calls the sub makefiles to build 
-    
+
+    3. Makefile - This is the main Makefile which calls the sub makefiles to build
+
        makefiles/ folder - There are separate makefiles for each directory that needs to be
             included in the given project. Each of the makefile starts with Makefile_ and ends
             with the Directory name (for example Makefile_HAL)
-       All the makefiles are exactly the same except for *_SRCS and *_DIR. 
+       All the makefiles are exactly the same except for *_SRCS and *_DIR.
         (The Makefile_Libraries is one of the exceptions and builds all the Libraries.)
-       
-       Makefile_common - is common to all the makefiles and "should not be changed". 
+
+       Makefile_common - is common to all the makefiles and "should not be changed".
 
     4. output/ folder - all the output is placed in this directory
              depend/ - all the depdencies created by the Make are placed in this folder
@@ -46,12 +46,12 @@ Adding New makefiles:
     - make a copy of one of the makefiles in the makefiles/ folder and rename it to
       reflect the name of the folder you want to include (for example Makefile_YourTest)
     - change the all *_DIR references to YOURTEST_DIR and *_SRCS to YOURTEST_SRCS
-    - in the main Makefile 
+    - in the main Makefile
        - add a new Target to the line starting with " $(OUTPUT_FILE).o: "
        - create build commands for the new Target as .PHONY objects point to your new makefile
 
 Building:
-     Make sure "C:\GnuWin32\bin" is the first in the Path and TC_PATH is properly set.
+     Make sure "C:\GnuWin32\bin" is the first in the Path and QORC_TC_PATH is properly set.
      - At the command prompt just type "make" to build all
      - Type "make clean" to delete all the object files and output built
      - type "make target" to selectively build a Target (for example, "make HAL")
@@ -59,4 +59,4 @@ Building:
 
    On a successfull build, output/bin will contain
      - *.bin, *.elf, *.map files
-  
+

--- a/qf_apps/qf_mqttsn_ai_app/GCC_Project/config.mk
+++ b/qf_apps/qf_mqttsn_ai_app/GCC_Project/config.mk
@@ -143,7 +143,7 @@ PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
 ifndef QORC_TC_PATH
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell which arm-none-eabi-gcc))
 export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
 endif #QORC_TC_PATH
 

--- a/qf_apps/qf_mqttsn_ai_app/GCC_Project/config.mk
+++ b/qf_apps/qf_mqttsn_ai_app/GCC_Project/config.mk
@@ -102,21 +102,21 @@ FIND_TOOL_DIR := $(shell where /r c:\progra~2 arm-none-eabi-gcc)
 endif
 
 ifdef FIND_TOOL_DIR
-export TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
+export QORC_TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
 endif
 
 #Override with your own tool direcoty
-#export TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+#export QORC_TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
 
-export NM="$(TC_PATH)\arm-none-eabi-nm"
-export LD="$(TC_PATH)\arm-none-eabi-gcc"
-export AS="$(TC_PATH)\arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)\arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)\arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)\arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)\arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)\arm-none-eabi-objcopy"
 ################
 else
 ################ Linux ###################
@@ -142,29 +142,31 @@ TMPVAR = $(subst ${DIR_SEP}, ,${APP_DIR})
 PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell whereis arm-none-eabi-gcc))
-export TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+ifndef QORC_TC_PATH
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+endif #QORC_TC_PATH
 
 # Allow TOOL to be provided on the command line
-# ie;   make -f Makefile TC_PATH=/some/path/
+# ie;   make -f Makefile QORC_TC_PATH=/some/path/
 
-ifndef TC_PATH
+ifndef QORC_TC_PATH
 #Override with your own tool directory
 #use full path. do not use ~/ as a relative path
-#export TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
-#export TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
-export TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
+#export QORC_TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
+#export QORC_TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
+export QORC_TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
 endif
 
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
-export NM="$(TC_PATH)/arm-none-eabi-nm"
-export LD="$(TC_PATH)/arm-none-eabi-gcc"
-export AS="$(TC_PATH)/arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)/arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)/arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)/arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)/arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)/arm-none-eabi-objcopy"
 ################
 endif
 ################

--- a/qf_apps/qf_ssi_ai_app/GCC_Project/Readme.txt
+++ b/qf_apps/qf_ssi_ai_app/GCC_Project/Readme.txt
@@ -1,12 +1,12 @@
-This is Readme.txt file for creating and building QuickAI Projects using 
-open-source GCC Tools and the provided Makefiles. 
+This is Readme.txt file for creating and building QuickAI Projects using
+open-source GCC Tools and the provided Makefiles.
 
 Requirements:
 
 The following open-source tools are needed in order to build using Makefiles.
 
 - ARM GCC toolchain available for download from
-    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/ 
+    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/
 - GNU Make program Version 3.81 available for download from
     - https://sourceforge.net/projects/gnuwin32/files/make/3.81
 
@@ -15,24 +15,24 @@ Overview:
 The following is a brief description of Makefile Architecture used for QuickAI SDK.
 
     There are 2 configuration setup files and a main Makefile under GCC_Project directory.
- 
+
     1. config.mk - selects the operating system environment to use, "Windows" or "Linux"
       -set BUILD_SYS=WINCMD - for Windows or comment it out for Linux
-      Note: 
+      Note:
         On Windows 10, there may be a problem to "auto-detect" the ARM Gnu Embedded Tool
-        Chain path. Then explicit set the TC_PATH to where the ARM GCC tools are installed.
+        Chain path. Then explicit set the QORC_TC_PATH to where the ARM GCC tools are installed.
       -
     2. config-GCC.mk - sets the GCC compiler options, source directories and "output file"
-    
-    3. Makefile - This is the main Makefile which calls the sub makefiles to build 
-    
+
+    3. Makefile - This is the main Makefile which calls the sub makefiles to build
+
        makefiles/ folder - There are separate makefiles for each directory that needs to be
             included in the given project. Each of the makefile starts with Makefile_ and ends
             with the Directory name (for example Makefile_HAL)
-       All the makefiles are exactly the same except for *_SRCS and *_DIR. 
+       All the makefiles are exactly the same except for *_SRCS and *_DIR.
         (The Makefile_Libraries is one of the exceptions and builds all the Libraries.)
-       
-       Makefile_common - is common to all the makefiles and "should not be changed". 
+
+       Makefile_common - is common to all the makefiles and "should not be changed".
 
     4. output/ folder - all the output is placed in this directory
              depend/ - all the depdencies created by the Make are placed in this folder
@@ -46,12 +46,12 @@ Adding New makefiles:
     - make a copy of one of the makefiles in the makefiles/ folder and rename it to
       reflect the name of the folder you want to include (for example Makefile_YourTest)
     - change the all *_DIR references to YOURTEST_DIR and *_SRCS to YOURTEST_SRCS
-    - in the main Makefile 
+    - in the main Makefile
        - add a new Target to the line starting with " $(OUTPUT_FILE).o: "
        - create build commands for the new Target as .PHONY objects point to your new makefile
 
 Building:
-     Make sure "C:\GnuWin32\bin" is the first in the Path and TC_PATH is properly set.
+     Make sure "C:\GnuWin32\bin" is the first in the Path and QORC_TC_PATH is properly set.
      - At the command prompt just type "make" to build all
      - Type "make clean" to delete all the object files and output built
      - type "make target" to selectively build a Target (for example, "make HAL")
@@ -59,4 +59,4 @@ Building:
 
    On a successfull build, output/bin will contain
      - *.bin, *.out, *.map files
-  
+

--- a/qf_apps/qf_ssi_ai_app/GCC_Project/config.mk
+++ b/qf_apps/qf_ssi_ai_app/GCC_Project/config.mk
@@ -144,7 +144,7 @@ TMPVAR = $(subst ${DIR_SEP}, ,${APP_DIR})
 PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 ifndef QORC_TC_PATH
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell which arm-none-eabi-gcc))
 export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
 endif #QORC_TC_PATH
 # Allow TOOL to be provided on the command line

--- a/qf_apps/qf_ssi_ai_app/GCC_Project/config.mk
+++ b/qf_apps/qf_ssi_ai_app/GCC_Project/config.mk
@@ -103,22 +103,22 @@ FIND_TOOL_DIR := $(shell where /r c:\progra~2 arm-none-eabi-gcc)
 endif
 
 ifdef FIND_TOOL_DIR
-export TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
+export QORC_TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
 endif
 
 #Override with your own tool direcoty
-#export TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+#export QORC_TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
 
-export NM="$(TC_PATH)\arm-none-eabi-nm"
-export LD="$(TC_PATH)\arm-none-eabi-g++"
-export AS="$(TC_PATH)\arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)\arm-none-eabi-gcc" -c
-export CPLUSPLUS="$(TC_PATH)\arm-none-eabi-g++" -c
-export ELF2BIN="$(TC_PATH)\arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)\arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)\arm-none-eabi-g++"
+export AS="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export CPLUSPLUS="$(QORC_TC_PATH)\arm-none-eabi-g++" -c
+export ELF2BIN="$(QORC_TC_PATH)\arm-none-eabi-objcopy"
 ################
 else
 ################ Linux ###################
@@ -143,31 +143,31 @@ export APP_DIR = $(subst /GCC_Project,,${PROJ_DIR})
 TMPVAR = $(subst ${DIR_SEP}, ,${APP_DIR})
 PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
-
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell whereis arm-none-eabi-gcc))
-export TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
-
+ifndef QORC_TC_PATH
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+endif #QORC_TC_PATH
 # Allow TOOL to be provided on the command line
-# ie;   make -f Makefile TC_PATH=/some/path/
+# ie;   make -f Makefile QORC_TC_PATH=/some/path/
 
-ifndef TC_PATH
+ifndef QORC_TC_PATH
 #Override with your own tool directory
 #use full path. do not use ~/ as a relative path
-#export TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
-#export TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
-export TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
+#export QORC_TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
+#export QORC_TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
+export QORC_TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
 endif
 
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
-export NM="$(TC_PATH)/arm-none-eabi-nm"
-export LD="$(TC_PATH)/arm-none-eabi-g++"
-export AS="$(TC_PATH)/arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)/arm-none-eabi-gcc" -c
-export CPLUSPLUS="$(TC_PATH)/arm-none-eabi-g++" -c
-export ELF2BIN="$(TC_PATH)/arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)/arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)/arm-none-eabi-g++"
+export AS="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export CPLUSPLUS="$(QORC_TC_PATH)/arm-none-eabi-g++" -c
+export ELF2BIN="$(QORC_TC_PATH)/arm-none-eabi-objcopy"
 ################
 endif
 ################

--- a/qf_vr_apps/qf_1micvr_app/GCC_Project/Readme.txt
+++ b/qf_vr_apps/qf_1micvr_app/GCC_Project/Readme.txt
@@ -1,12 +1,12 @@
-This is Readme.txt file for creating and building qorc-sdk Projects using 
-open-source GCC Tools and the provided Makefiles. 
+This is Readme.txt file for creating and building qorc-sdk Projects using
+open-source GCC Tools and the provided Makefiles.
 
 Requirements:
 
 The following open-source tools are needed in order to build using Makefiles.
 
 - ARM GCC toolchain available for download from
-    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/ 
+    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/
 - GNU Make program Version 3.81 available for download from
     - https://sourceforge.net/projects/gnuwin32/files/make/3.81
 
@@ -15,24 +15,24 @@ Overview:
 The following is a brief description of Makefile Architecture used for qorc-sdk.
 
     There are 2 configuration setup files and a main Makefile under GCC_Project directory.
- 
+
     1. config.mk - selects the operating system environment to use, "Windows" or "Linux"
       -set BUILD_SYS=WINCMD - for Windows or comment it out for Linux
-      Note: 
+      Note:
         On Windows 10, there may be a problem to "auto-detect" the ARM Gnu Embedded Tool
-        Chain path. Then explicit set the TC_PATH to where the ARM GCC tools are installed.
+        Chain path. Then explicit set the QORC_TC_PATH to where the ARM GCC tools are installed.
       -
     2. config-GCC.mk - sets the GCC compiler options, source directories and "output file"
-    
-    3. Makefile - This is the main Makefile which calls the sub makefiles to build 
-    
+
+    3. Makefile - This is the main Makefile which calls the sub makefiles to build
+
        makefiles/ folder - There are separate makefiles for each directory that needs to be
             included in the given project. Each of the makefile starts with Makefile_ and ends
             with the Directory name (for example Makefile_HAL)
-       All the makefiles are exactly the same except for *_SRCS and *_DIR. 
+       All the makefiles are exactly the same except for *_SRCS and *_DIR.
         (The Makefile_Libraries is one of the exceptions and builds all the Libraries.)
-       
-       Makefile_common - is common to all the makefiles and "should not be changed". 
+
+       Makefile_common - is common to all the makefiles and "should not be changed".
 
     4. output/ folder - all the output is placed in this directory
              depend/ - all the depdencies created by the Make are placed in this folder
@@ -46,12 +46,12 @@ Adding New makefiles:
     - make a copy of one of the makefiles in the makefiles/ folder and rename it to
       reflect the name of the folder you want to include (for example Makefile_YourTest)
     - change the all *_DIR references to YOURTEST_DIR and *_SRCS to YOURTEST_SRCS
-    - in the main Makefile 
+    - in the main Makefile
        - add a new Target to the line starting with " $(OUTPUT_FILE).o: "
        - create build commands for the new Target as .PHONY objects point to your new makefile
 
 Building:
-     Make sure "C:\GnuWin32\bin" is the first in the Path and TC_PATH is properly set.
+     Make sure "C:\GnuWin32\bin" is the first in the Path and QORC_TC_PATH is properly set.
      - At the command prompt just type "make" to build all
      - Type "make clean" to delete all the object files and output built
      - type "make target" to selectively build a Target (for example, "make HAL")
@@ -59,4 +59,4 @@ Building:
 
    On a successfull build, output/bin will contain
      - *.bin, *.out, *.map files
-  
+

--- a/qf_vr_apps/qf_1micvr_app/GCC_Project/config.mk
+++ b/qf_vr_apps/qf_1micvr_app/GCC_Project/config.mk
@@ -143,7 +143,7 @@ PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
 ifndef QORC_TC_PATH
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell which arm-none-eabi-gcc))
 export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
 endif #QORC_TC_PATH
 

--- a/qf_vr_apps/qf_1micvr_app/GCC_Project/config.mk
+++ b/qf_vr_apps/qf_1micvr_app/GCC_Project/config.mk
@@ -5,8 +5,8 @@
 # By default, many commands are hidden
 # To enable VERBOSE mode, there are TWO options
 # both are enabled via the command line:
-# Option 1: "make HIDE=" 
-# Option 2: "make v=1" 
+# Option 1: "make HIDE="
+# Option 2: "make v=1"
 HIDE ?=@
 ifeq (x"${v}",x"1")
 override HIDE=
@@ -102,22 +102,22 @@ FIND_TOOL_DIR := $(shell where /r c:\progra~2 arm-none-eabi-gcc)
 endif
 
 ifdef FIND_TOOL_DIR
-export TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
+export QORC_TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
 endif
 
 #Override with your own tool direcoty
-#export TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+#export QORC_TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
 
-export NM="$(TC_PATH)\arm-none-eabi-nm"
-export LD="$(TC_PATH)\arm-none-eabi-gcc"
-export AS="$(TC_PATH)\arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)\arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)\arm-none-eabi-objcopy"
-export AR="$(TC_PATH)\arm-none-eabi-ar"
+export NM="$(QORC_TC_PATH)\arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)\arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)\arm-none-eabi-objcopy"
+export AR="$(QORC_TC_PATH)\arm-none-eabi-ar"
 ################
 else
 ################ Linux ###################
@@ -142,29 +142,31 @@ TMPVAR = $(subst ${DIR_SEP}, ,${APP_DIR})
 PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell whereis arm-none-eabi-gcc))
-export TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+ifndef QORC_TC_PATH
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+endif #QORC_TC_PATH
 
 # Allow TOOL to be provided on the command line
-# ie;   make -f Makefile TC_PATH=/some/path/
+# ie;   make -f Makefile QORC_TC_PATH=/some/path/
 
-ifndef TC_PATH
+ifndef QORC_TC_PATH
 #Override with your own tool directory
 #use full path. do not use ~/ as a relative path
-#export TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
-#export TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
-export TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
+#export QORC_TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
+#export QORC_TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
+export QORC_TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
 endif
 
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
-export NM="$(TC_PATH)/arm-none-eabi-nm"
-export LD="$(TC_PATH)/arm-none-eabi-gcc"
-export AS="$(TC_PATH)/arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)/arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)/arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)/arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)/arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)/arm-none-eabi-objcopy"
 ################
 endif
 ################

--- a/qf_vr_apps/qf_2micvr_app/GCC_Project/Readme.txt
+++ b/qf_vr_apps/qf_2micvr_app/GCC_Project/Readme.txt
@@ -1,12 +1,12 @@
-This is Readme.txt file for creating and building qorc-sdk Projects using 
-open-source GCC Tools and the provided Makefiles. 
+This is Readme.txt file for creating and building qorc-sdk Projects using
+open-source GCC Tools and the provided Makefiles.
 
 Requirements:
 
 The following open-source tools are needed in order to build using Makefiles.
 
 - ARM GCC toolchain available for download from
-    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/ 
+    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/
 - GNU Make program Version 3.81 available for download from
     - https://sourceforge.net/projects/gnuwin32/files/make/3.81
 
@@ -15,24 +15,24 @@ Overview:
 The following is a brief description of Makefile Architecture used for qorc-sdk.
 
     There are 2 configuration setup files and a main Makefile under GCC_Project directory.
- 
+
     1. config.mk - selects the operating system environment to use, "Windows" or "Linux"
       -set BUILD_SYS=WINCMD - for Windows or comment it out for Linux
-      Note: 
+      Note:
         On Windows 10, there may be a problem to "auto-detect" the ARM Gnu Embedded Tool
-        Chain path. Then explicit set the TC_PATH to where the ARM GCC tools are installed.
+        Chain path. Then explicit set the QORC_TC_PATH to where the ARM GCC tools are installed.
       -
     2. config-GCC.mk - sets the GCC compiler options, source directories and "output file"
-    
-    3. Makefile - This is the main Makefile which calls the sub makefiles to build 
-    
+
+    3. Makefile - This is the main Makefile which calls the sub makefiles to build
+
        makefiles/ folder - There are separate makefiles for each directory that needs to be
             included in the given project. Each of the makefile starts with Makefile_ and ends
             with the Directory name (for example Makefile_HAL)
-       All the makefiles are exactly the same except for *_SRCS and *_DIR. 
+       All the makefiles are exactly the same except for *_SRCS and *_DIR.
         (The Makefile_Libraries is one of the exceptions and builds all the Libraries.)
-       
-       Makefile_common - is common to all the makefiles and "should not be changed". 
+
+       Makefile_common - is common to all the makefiles and "should not be changed".
 
     4. output/ folder - all the output is placed in this directory
              depend/ - all the depdencies created by the Make are placed in this folder
@@ -46,12 +46,12 @@ Adding New makefiles:
     - make a copy of one of the makefiles in the makefiles/ folder and rename it to
       reflect the name of the folder you want to include (for example Makefile_YourTest)
     - change the all *_DIR references to YOURTEST_DIR and *_SRCS to YOURTEST_SRCS
-    - in the main Makefile 
+    - in the main Makefile
        - add a new Target to the line starting with " $(OUTPUT_FILE).o: "
        - create build commands for the new Target as .PHONY objects point to your new makefile
 
 Building:
-     Make sure "C:\GnuWin32\bin" is the first in the Path and TC_PATH is properly set.
+     Make sure "C:\GnuWin32\bin" is the first in the Path and QORC_TC_PATH is properly set.
      - At the command prompt just type "make" to build all
      - Type "make clean" to delete all the object files and output built
      - type "make target" to selectively build a Target (for example, "make HAL")
@@ -59,4 +59,4 @@ Building:
 
    On a successfull build, output/bin will contain
      - *.bin, *.out, *.map files
-  
+

--- a/qf_vr_apps/qf_2micvr_app/GCC_Project/config.mk
+++ b/qf_vr_apps/qf_2micvr_app/GCC_Project/config.mk
@@ -143,7 +143,7 @@ PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
 ifndef QORC_TC_PATH
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell which arm-none-eabi-gcc))
 export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
 endif #QORC_TC_PATH
 

--- a/qf_vr_apps/qf_2micvr_app/GCC_Project/config.mk
+++ b/qf_vr_apps/qf_2micvr_app/GCC_Project/config.mk
@@ -5,8 +5,8 @@
 # By default, many commands are hidden
 # To enable VERBOSE mode, there are TWO options
 # both are enabled via the command line:
-# Option 1: "make HIDE=" 
-# Option 2: "make v=1" 
+# Option 1: "make HIDE="
+# Option 2: "make v=1"
 HIDE ?=@
 ifeq (x"${v}",x"1")
 override HIDE=
@@ -102,22 +102,22 @@ FIND_TOOL_DIR := $(shell where /r c:\progra~2 arm-none-eabi-gcc)
 endif
 
 ifdef FIND_TOOL_DIR
-export TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
+export QORC_TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
 endif
 
 #Override with your own tool direcoty
-#export TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+#export QORC_TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
 
-export NM="$(TC_PATH)\arm-none-eabi-nm"
-export LD="$(TC_PATH)\arm-none-eabi-gcc"
-export AS="$(TC_PATH)\arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)\arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)\arm-none-eabi-objcopy"
-export AR="$(TC_PATH)\arm-none-eabi-ar"
+export NM="$(QORC_TC_PATH)\arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)\arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)\arm-none-eabi-objcopy"
+export AR="$(QORC_TC_PATH)\arm-none-eabi-ar"
 ################
 else
 ################ Linux ###################
@@ -142,29 +142,31 @@ TMPVAR = $(subst ${DIR_SEP}, ,${APP_DIR})
 PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell whereis arm-none-eabi-gcc))
-export TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+ifndef QORC_TC_PATH
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+endif #QORC_TC_PATH
 
 # Allow TOOL to be provided on the command line
-# ie;   make -f Makefile TC_PATH=/some/path/
+# ie;   make -f Makefile QORC_TC_PATH=/some/path/
 
-ifndef TC_PATH
+ifndef QORC_TC_PATH
 #Override with your own tool directory
 #use full path. do not use ~/ as a relative path
-#export TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
-#export TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
-export TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
+#export QORC_TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
+#export QORC_TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
+export QORC_TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
 endif
 
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
-export NM="$(TC_PATH)/arm-none-eabi-nm"
-export LD="$(TC_PATH)/arm-none-eabi-gcc"
-export AS="$(TC_PATH)/arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)/arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)/arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)/arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)/arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)/arm-none-eabi-objcopy"
 ################
 endif
 ################

--- a/qf_vr_apps/qf_host_app/GCC_Project/Readme.txt
+++ b/qf_vr_apps/qf_host_app/GCC_Project/Readme.txt
@@ -1,12 +1,12 @@
-This is Readme.txt file for creating and building qorc-sdk Projects using 
-open-source GCC Tools and the provided Makefiles. 
+This is Readme.txt file for creating and building qorc-sdk Projects using
+open-source GCC Tools and the provided Makefiles.
 
 Requirements:
 
 The following open-source tools are needed in order to build using Makefiles.
 
 - ARM GCC toolchain available for download from
-    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/ 
+    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/
 - GNU Make program Version 3.81 available for download from
     - https://sourceforge.net/projects/gnuwin32/files/make/3.81
 
@@ -15,24 +15,24 @@ Overview:
 The following is a brief description of Makefile Architecture used for qorc-sdk.
 
     There are 2 configuration setup files and a main Makefile under GCC_Project directory.
- 
+
     1. config.mk - selects the operating system environment to use, "Windows" or "Linux"
       -set BUILD_SYS=WINCMD - for Windows or comment it out for Linux
-      Note: 
+      Note:
         On Windows 10, there may be a problem to "auto-detect" the ARM Gnu Embedded Tool
-        Chain path. Then explicit set the TC_PATH to where the ARM GCC tools are installed.
+        Chain path. Then explicit set the QORC_TC_PATH to where the ARM GCC tools are installed.
       -
     2. config-GCC.mk - sets the GCC compiler options, source directories and "output file"
-    
-    3. Makefile - This is the main Makefile which calls the sub makefiles to build 
-    
+
+    3. Makefile - This is the main Makefile which calls the sub makefiles to build
+
        makefiles/ folder - There are separate makefiles for each directory that needs to be
             included in the given project. Each of the makefile starts with Makefile_ and ends
             with the Directory name (for example Makefile_HAL)
-       All the makefiles are exactly the same except for *_SRCS and *_DIR. 
+       All the makefiles are exactly the same except for *_SRCS and *_DIR.
         (The Makefile_Libraries is one of the exceptions and builds all the Libraries.)
-       
-       Makefile_common - is common to all the makefiles and "should not be changed". 
+
+       Makefile_common - is common to all the makefiles and "should not be changed".
 
     4. output/ folder - all the output is placed in this directory
              depend/ - all the depdencies created by the Make are placed in this folder
@@ -46,12 +46,12 @@ Adding New makefiles:
     - make a copy of one of the makefiles in the makefiles/ folder and rename it to
       reflect the name of the folder you want to include (for example Makefile_YourTest)
     - change the all *_DIR references to YOURTEST_DIR and *_SRCS to YOURTEST_SRCS
-    - in the main Makefile 
+    - in the main Makefile
        - add a new Target to the line starting with " $(OUTPUT_FILE).o: "
        - create build commands for the new Target as .PHONY objects point to your new makefile
 
 Building:
-     Make sure "C:\GnuWin32\bin" is the first in the Path and TC_PATH is properly set.
+     Make sure "C:\GnuWin32\bin" is the first in the Path and QORC_TC_PATH is properly set.
      - At the command prompt just type "make" to build all
      - Type "make clean" to delete all the object files and output built
      - type "make target" to selectively build a Target (for example, "make HAL")
@@ -59,4 +59,4 @@ Building:
 
    On a successfull build, output/bin will contain
      - *.bin, *.out, *.map files
-  
+

--- a/qf_vr_apps/qf_host_app/GCC_Project/config.mk
+++ b/qf_vr_apps/qf_host_app/GCC_Project/config.mk
@@ -142,7 +142,7 @@ TMPVAR = $(subst ${DIR_SEP}, ,${APP_DIR})
 PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 ifndef QORC_TC_PATH
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell which arm-none-eabi-gcc))
 export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
 endif #QORC_TC_PATH
 

--- a/qf_vr_apps/qf_host_app/GCC_Project/config.mk
+++ b/qf_vr_apps/qf_host_app/GCC_Project/config.mk
@@ -102,22 +102,22 @@ FIND_TOOL_DIR := $(shell where /r c:\progra~2 arm-none-eabi-gcc)
 endif
 
 ifdef FIND_TOOL_DIR
-export TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
+export QORC_TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
 endif
 
 #Override with your own tool direcoty
-#export TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+#export QORC_TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
 
-export NM="$(TC_PATH)\arm-none-eabi-nm"
-export LD="$(TC_PATH)\arm-none-eabi-gcc"
-export AS="$(TC_PATH)\arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)\arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)\arm-none-eabi-objcopy"
-export AR="$(TC_PATH)\arm-none-eabi-ar"
+export NM="$(QORC_TC_PATH)\arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)\arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)\arm-none-eabi-objcopy"
+export AR="$(QORC_TC_PATH)\arm-none-eabi-ar"
 ################
 else
 ################ Linux ###################
@@ -141,29 +141,31 @@ export APP_DIR = $(subst /GCC_Project,,${PROJ_DIR})
 TMPVAR = $(subst ${DIR_SEP}, ,${APP_DIR})
 PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell whereis arm-none-eabi-gcc))
-export TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+ifndef QORC_TC_PATH
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+endif #QORC_TC_PATH
 
 # Allow TOOL to be provided on the command line
-# ie;   make -f Makefile TC_PATH=/some/path/
+# ie;   make -f Makefile QORC_TC_PATH=/some/path/
 
-ifndef TC_PATH
+ifndef QORC_TC_PATH
 #Override with your own tool directory
 #use full path. do not use ~/ as a relative path
-#export TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
-#export TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
-export TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
+#export QORC_TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
+#export QORC_TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
+export QORC_TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
 endif
 
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
-export NM="$(TC_PATH)/arm-none-eabi-nm"
-export LD="$(TC_PATH)/arm-none-eabi-gcc"
-export AS="$(TC_PATH)/arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)/arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)/arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)/arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)/arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)/arm-none-eabi-objcopy"
 ################
 endif
 ################

--- a/qf_vr_apps/qf_vr_i2s_app/GCC_Project/Readme.txt
+++ b/qf_vr_apps/qf_vr_i2s_app/GCC_Project/Readme.txt
@@ -1,12 +1,12 @@
-This is Readme.txt file for creating and building qorc-sdk Projects using 
-open-source GCC Tools and the provided Makefiles. 
+This is Readme.txt file for creating and building qorc-sdk Projects using
+open-source GCC Tools and the provided Makefiles.
 
 Requirements:
 
 The following open-source tools are needed in order to build using Makefiles.
 
 - ARM GCC toolchain available for download from
-    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/ 
+    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/
 - GNU Make program Version 3.81 available for download from
     - https://sourceforge.net/projects/gnuwin32/files/make/3.81
 
@@ -15,24 +15,24 @@ Overview:
 The following is a brief description of Makefile Architecture used for qorc-sdk.
 
     There are 2 configuration setup files and a main Makefile under GCC_Project directory.
- 
+
     1. config.mk - selects the operating system environment to use, "Windows" or "Linux"
       -set BUILD_SYS=WINCMD - for Windows or comment it out for Linux
-      Note: 
+      Note:
         On Windows 10, there may be a problem to "auto-detect" the ARM Gnu Embedded Tool
-        Chain path. Then explicit set the TC_PATH to where the ARM GCC tools are installed.
+        Chain path. Then explicit set the QORC_TC_PATH to where the ARM GCC tools are installed.
       -
     2. config-GCC.mk - sets the GCC compiler options, source directories and "output file"
-    
-    3. Makefile - This is the main Makefile which calls the sub makefiles to build 
-    
+
+    3. Makefile - This is the main Makefile which calls the sub makefiles to build
+
        makefiles/ folder - There are separate makefiles for each directory that needs to be
             included in the given project. Each of the makefile starts with Makefile_ and ends
             with the Directory name (for example Makefile_HAL)
-       All the makefiles are exactly the same except for *_SRCS and *_DIR. 
+       All the makefiles are exactly the same except for *_SRCS and *_DIR.
         (The Makefile_Libraries is one of the exceptions and builds all the Libraries.)
-       
-       Makefile_common - is common to all the makefiles and "should not be changed". 
+
+       Makefile_common - is common to all the makefiles and "should not be changed".
 
     4. output/ folder - all the output is placed in this directory
              depend/ - all the depdencies created by the Make are placed in this folder
@@ -46,12 +46,12 @@ Adding New makefiles:
     - make a copy of one of the makefiles in the makefiles/ folder and rename it to
       reflect the name of the folder you want to include (for example Makefile_YourTest)
     - change the all *_DIR references to YOURTEST_DIR and *_SRCS to YOURTEST_SRCS
-    - in the main Makefile 
+    - in the main Makefile
        - add a new Target to the line starting with " $(OUTPUT_FILE).o: "
        - create build commands for the new Target as .PHONY objects point to your new makefile
 
 Building:
-     Make sure "C:\GnuWin32\bin" is the first in the Path and TC_PATH is properly set.
+     Make sure "C:\GnuWin32\bin" is the first in the Path and QORC_TC_PATH is properly set.
      - At the command prompt just type "make" to build all
      - Type "make clean" to delete all the object files and output built
      - type "make target" to selectively build a Target (for example, "make HAL")
@@ -59,4 +59,4 @@ Building:
 
    On a successfull build, output/bin will contain
      - *.bin, *.out, *.map files
-  
+

--- a/qf_vr_apps/qf_vr_i2s_app/GCC_Project/config.mk
+++ b/qf_vr_apps/qf_vr_i2s_app/GCC_Project/config.mk
@@ -143,7 +143,7 @@ PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
 ifndef QORC_TC_PATH
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell which arm-none-eabi-gcc))
 export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
 endif #QORC_TC_PATH
 

--- a/qf_vr_apps/qf_vr_i2s_app/GCC_Project/config.mk
+++ b/qf_vr_apps/qf_vr_i2s_app/GCC_Project/config.mk
@@ -5,8 +5,8 @@
 # By default, many commands are hidden
 # To enable VERBOSE mode, there are TWO options
 # both are enabled via the command line:
-# Option 1: "make HIDE=" 
-# Option 2: "make v=1" 
+# Option 1: "make HIDE="
+# Option 2: "make v=1"
 HIDE ?=@
 ifeq (x"${v}",x"1")
 override HIDE=
@@ -102,22 +102,22 @@ FIND_TOOL_DIR := $(shell where /r c:\progra~2 arm-none-eabi-gcc)
 endif
 
 ifdef FIND_TOOL_DIR
-export TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
+export QORC_TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
 endif
 
 #Override with your own tool direcoty
-#export TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+#export QORC_TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
 
-export NM="$(TC_PATH)\arm-none-eabi-nm"
-export LD="$(TC_PATH)\arm-none-eabi-gcc"
-export AS="$(TC_PATH)\arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)\arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)\arm-none-eabi-objcopy"
-export AR="$(TC_PATH)\arm-none-eabi-ar"
+export NM="$(QORC_TC_PATH)\arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)\arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)\arm-none-eabi-objcopy"
+export AR="$(QORC_TC_PATH)\arm-none-eabi-ar"
 ################
 else
 ################ Linux ###################
@@ -142,29 +142,31 @@ TMPVAR = $(subst ${DIR_SEP}, ,${APP_DIR})
 PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell whereis arm-none-eabi-gcc))
-export TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+ifndef QORC_TC_PATH
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+endif #QORC_TC_PATH
 
 # Allow TOOL to be provided on the command line
-# ie;   make -f Makefile TC_PATH=/some/path/
+# ie;   make -f Makefile QORC_TC_PATH=/some/path/
 
-ifndef TC_PATH
+ifndef QORC_TC_PATH
 #Override with your own tool directory
 #use full path. do not use ~/ as a relative path
-#export TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
-#export TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
-export TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
+#export QORC_TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
+#export QORC_TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
+export QORC_TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
 endif
 
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
-export NM="$(TC_PATH)/arm-none-eabi-nm"
-export LD="$(TC_PATH)/arm-none-eabi-gcc"
-export AS="$(TC_PATH)/arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)/arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)/arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)/arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)/arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)/arm-none-eabi-objcopy"
 ################
 endif
 ################

--- a/qf_vr_apps/qf_vr_opus_app/GCC_Project/Readme.txt
+++ b/qf_vr_apps/qf_vr_opus_app/GCC_Project/Readme.txt
@@ -1,12 +1,12 @@
-This is Readme.txt file for creating and building qorc-sdk Projects using 
-open-source GCC Tools and the provided Makefiles. 
+This is Readme.txt file for creating and building qorc-sdk Projects using
+open-source GCC Tools and the provided Makefiles.
 
 Requirements:
 
 The following open-source tools are needed in order to build using Makefiles.
 
 - ARM GCC toolchain available for download from
-    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/ 
+    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/
 - GNU Make program Version 3.81 available for download from
     - https://sourceforge.net/projects/gnuwin32/files/make/3.81
 
@@ -15,24 +15,24 @@ Overview:
 The following is a brief description of Makefile Architecture used for qorc-sdk.
 
     There are 2 configuration setup files and a main Makefile under GCC_Project directory.
- 
+
     1. config.mk - selects the operating system environment to use, "Windows" or "Linux"
       -set BUILD_SYS=WINCMD - for Windows or comment it out for Linux
-      Note: 
+      Note:
         On Windows 10, there may be a problem to "auto-detect" the ARM Gnu Embedded Tool
-        Chain path. Then explicit set the TC_PATH to where the ARM GCC tools are installed.
+        Chain path. Then explicit set the QORC_TC_PATH to where the ARM GCC tools are installed.
       -
     2. config-GCC.mk - sets the GCC compiler options, source directories and "output file"
-    
-    3. Makefile - This is the main Makefile which calls the sub makefiles to build 
-    
+
+    3. Makefile - This is the main Makefile which calls the sub makefiles to build
+
        makefiles/ folder - There are separate makefiles for each directory that needs to be
             included in the given project. Each of the makefile starts with Makefile_ and ends
             with the Directory name (for example Makefile_HAL)
-       All the makefiles are exactly the same except for *_SRCS and *_DIR. 
+       All the makefiles are exactly the same except for *_SRCS and *_DIR.
         (The Makefile_Libraries is one of the exceptions and builds all the Libraries.)
-       
-       Makefile_common - is common to all the makefiles and "should not be changed". 
+
+       Makefile_common - is common to all the makefiles and "should not be changed".
 
     4. output/ folder - all the output is placed in this directory
              depend/ - all the depdencies created by the Make are placed in this folder
@@ -46,12 +46,12 @@ Adding New makefiles:
     - make a copy of one of the makefiles in the makefiles/ folder and rename it to
       reflect the name of the folder you want to include (for example Makefile_YourTest)
     - change the all *_DIR references to YOURTEST_DIR and *_SRCS to YOURTEST_SRCS
-    - in the main Makefile 
+    - in the main Makefile
        - add a new Target to the line starting with " $(OUTPUT_FILE).o: "
        - create build commands for the new Target as .PHONY objects point to your new makefile
 
 Building:
-     Make sure "C:\GnuWin32\bin" is the first in the Path and TC_PATH is properly set.
+     Make sure "C:\GnuWin32\bin" is the first in the Path and QORC_TC_PATH is properly set.
      - At the command prompt just type "make" to build all
      - Type "make clean" to delete all the object files and output built
      - type "make target" to selectively build a Target (for example, "make HAL")
@@ -59,4 +59,4 @@ Building:
 
    On a successfull build, output/bin will contain
      - *.bin, *.out, *.map files
-  
+

--- a/qf_vr_apps/qf_vr_opus_app/GCC_Project/config.mk
+++ b/qf_vr_apps/qf_vr_opus_app/GCC_Project/config.mk
@@ -143,7 +143,7 @@ PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
 ifndef QORC_TC_PATH
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell which arm-none-eabi-gcc))
 export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
 endif #QORC_TC_PATH
 

--- a/qf_vr_apps/qf_vr_opus_app/GCC_Project/config.mk
+++ b/qf_vr_apps/qf_vr_opus_app/GCC_Project/config.mk
@@ -5,8 +5,8 @@
 # By default, many commands are hidden
 # To enable VERBOSE mode, there are TWO options
 # both are enabled via the command line:
-# Option 1: "make HIDE=" 
-# Option 2: "make v=1" 
+# Option 1: "make HIDE="
+# Option 2: "make v=1"
 HIDE ?=@
 ifeq (x"${v}",x"1")
 override HIDE=
@@ -102,22 +102,22 @@ FIND_TOOL_DIR := $(shell where /r c:\progra~2 arm-none-eabi-gcc)
 endif
 
 ifdef FIND_TOOL_DIR
-export TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
+export QORC_TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
 endif
 
 #Override with your own tool direcoty
-#export TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+#export QORC_TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
 
-export NM="$(TC_PATH)\arm-none-eabi-nm"
-export LD="$(TC_PATH)\arm-none-eabi-gcc"
-export AS="$(TC_PATH)\arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)\arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)\arm-none-eabi-objcopy"
-export AR="$(TC_PATH)\arm-none-eabi-ar"
+export NM="$(QORC_TC_PATH)\arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)\arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)\arm-none-eabi-objcopy"
+export AR="$(QORC_TC_PATH)\arm-none-eabi-ar"
 ################
 else
 ################ Linux ###################
@@ -142,29 +142,31 @@ TMPVAR = $(subst ${DIR_SEP}, ,${APP_DIR})
 PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell whereis arm-none-eabi-gcc))
-export TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+ifndef QORC_TC_PATH
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+endif #QORC_TC_PATH
 
 # Allow TOOL to be provided on the command line
-# ie;   make -f Makefile TC_PATH=/some/path/
+# ie;   make -f Makefile QORC_TC_PATH=/some/path/
 
-ifndef TC_PATH
+ifndef QORC_TC_PATH
 #Override with your own tool directory
 #use full path. do not use ~/ as a relative path
-#export TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
-#export TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
-export TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
+#export QORC_TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
+#export QORC_TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
+export QORC_TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
 endif
 
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
-export NM="$(TC_PATH)/arm-none-eabi-nm"
-export LD="$(TC_PATH)/arm-none-eabi-gcc"
-export AS="$(TC_PATH)/arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)/arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)/arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)/arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)/arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)/arm-none-eabi-objcopy"
 ################
 endif
 ################

--- a/qf_vr_apps/qf_vr_raw_app/GCC_Project/Readme.txt
+++ b/qf_vr_apps/qf_vr_raw_app/GCC_Project/Readme.txt
@@ -1,12 +1,12 @@
-This is Readme.txt file for creating and building qorc-sdk Projects using 
-open-source GCC Tools and the provided Makefiles. 
+This is Readme.txt file for creating and building qorc-sdk Projects using
+open-source GCC Tools and the provided Makefiles.
 
 Requirements:
 
 The following open-source tools are needed in order to build using Makefiles.
 
 - ARM GCC toolchain available for download from
-    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/ 
+    - https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/
 - GNU Make program Version 3.81 available for download from
     - https://sourceforge.net/projects/gnuwin32/files/make/3.81
 
@@ -15,24 +15,24 @@ Overview:
 The following is a brief description of Makefile Architecture used for qorc-sdk.
 
     There are 2 configuration setup files and a main Makefile under GCC_Project directory.
- 
+
     1. config.mk - selects the operating system environment to use, "Windows" or "Linux"
       -set BUILD_SYS=WINCMD - for Windows or comment it out for Linux
-      Note: 
+      Note:
         On Windows 10, there may be a problem to "auto-detect" the ARM Gnu Embedded Tool
-        Chain path. Then explicit set the TC_PATH to where the ARM GCC tools are installed.
+        Chain path. Then explicit set the QORC_TC_PATH to where the ARM GCC tools are installed.
       -
     2. config-GCC.mk - sets the GCC compiler options, source directories and "output file"
-    
-    3. Makefile - This is the main Makefile which calls the sub makefiles to build 
-    
+
+    3. Makefile - This is the main Makefile which calls the sub makefiles to build
+
        makefiles/ folder - There are separate makefiles for each directory that needs to be
             included in the given project. Each of the makefile starts with Makefile_ and ends
             with the Directory name (for example Makefile_HAL)
-       All the makefiles are exactly the same except for *_SRCS and *_DIR. 
+       All the makefiles are exactly the same except for *_SRCS and *_DIR.
         (The Makefile_Libraries is one of the exceptions and builds all the Libraries.)
-       
-       Makefile_common - is common to all the makefiles and "should not be changed". 
+
+       Makefile_common - is common to all the makefiles and "should not be changed".
 
     4. output/ folder - all the output is placed in this directory
              depend/ - all the depdencies created by the Make are placed in this folder
@@ -46,12 +46,12 @@ Adding New makefiles:
     - make a copy of one of the makefiles in the makefiles/ folder and rename it to
       reflect the name of the folder you want to include (for example Makefile_YourTest)
     - change the all *_DIR references to YOURTEST_DIR and *_SRCS to YOURTEST_SRCS
-    - in the main Makefile 
+    - in the main Makefile
        - add a new Target to the line starting with " $(OUTPUT_FILE).o: "
        - create build commands for the new Target as .PHONY objects point to your new makefile
 
 Building:
-     Make sure "C:\GnuWin32\bin" is the first in the Path and TC_PATH is properly set.
+     Make sure "C:\GnuWin32\bin" is the first in the Path and QORC_TC_PATH is properly set.
      - At the command prompt just type "make" to build all
      - Type "make clean" to delete all the object files and output built
      - type "make target" to selectively build a Target (for example, "make HAL")
@@ -59,4 +59,4 @@ Building:
 
    On a successfull build, output/bin will contain
      - *.bin, *.out, *.map files
-  
+

--- a/qf_vr_apps/qf_vr_raw_app/GCC_Project/config.mk
+++ b/qf_vr_apps/qf_vr_raw_app/GCC_Project/config.mk
@@ -143,7 +143,7 @@ PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
 ifndef QORC_TC_PATH
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell which arm-none-eabi-gcc))
 export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
 endif #QORC_TC_PATH
 

--- a/qf_vr_apps/qf_vr_raw_app/GCC_Project/config.mk
+++ b/qf_vr_apps/qf_vr_raw_app/GCC_Project/config.mk
@@ -5,8 +5,8 @@
 # By default, many commands are hidden
 # To enable VERBOSE mode, there are TWO options
 # both are enabled via the command line:
-# Option 1: "make HIDE=" 
-# Option 2: "make v=1" 
+# Option 1: "make HIDE="
+# Option 2: "make v=1"
 HIDE ?=@
 ifeq (x"${v}",x"1")
 override HIDE=
@@ -102,22 +102,22 @@ FIND_TOOL_DIR := $(shell where /r c:\progra~2 arm-none-eabi-gcc)
 endif
 
 ifdef FIND_TOOL_DIR
-export TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
+export QORC_TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
 endif
 
 #Override with your own tool direcoty
-#export TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+#export QORC_TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
 
-export NM="$(TC_PATH)\arm-none-eabi-nm"
-export LD="$(TC_PATH)\arm-none-eabi-gcc"
-export AS="$(TC_PATH)\arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)\arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)\arm-none-eabi-objcopy"
-export AR="$(TC_PATH)\arm-none-eabi-ar"
+export NM="$(QORC_TC_PATH)\arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)\arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)\arm-none-eabi-objcopy"
+export AR="$(QORC_TC_PATH)\arm-none-eabi-ar"
 ################
 else
 ################ Linux ###################
@@ -142,29 +142,31 @@ TMPVAR = $(subst ${DIR_SEP}, ,${APP_DIR})
 PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
-FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell whereis arm-none-eabi-gcc))
-export TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+ifndef QORC_TC_PATH
+FIND_TOOL_DIR := $(subst arm-none-eabi-gcc: ,,$(shell where arm-none-eabi-gcc))
+export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
+endif #QORC_TC_PATH
 
 # Allow TOOL to be provided on the command line
-# ie;   make -f Makefile TC_PATH=/some/path/
+# ie;   make -f Makefile QORC_TC_PATH=/some/path/
 
-ifndef TC_PATH
+ifndef QORC_TC_PATH
 #Override with your own tool directory
 #use full path. do not use ~/ as a relative path
-#export TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
-#export TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
-export TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
+#export QORC_TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
+#export QORC_TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
+export QORC_TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
 endif
 
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
-export NM="$(TC_PATH)/arm-none-eabi-nm"
-export LD="$(TC_PATH)/arm-none-eabi-gcc"
-export AS="$(TC_PATH)/arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)/arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)/arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)/arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)/arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)/arm-none-eabi-objcopy"
 ################
 endif
 ################


### PR DESCRIPTION
Fixes for https://github.com/QuickLogic-Corp/qorc-sdk/issues/82 and https://github.com/QuickLogic-Corp/qorc-sdk/issues/42

Using envsetup.sh - adds QORC_TC_PATH to shell env, using the default install directory. 

renames TC_PATH to QORC_TC_PATH to have clearer defined variables