### PR TITLE
Added macro to send known sawtooth pattern for SSI app

### DIFF
--- a/qf_apps/qf_ssi_ai_app/inc/Fw_global_config.h
+++ b/qf_apps/qf_ssi_ai_app/inc/Fw_global_config.h
@@ -69,6 +69,11 @@
 // Datablocks are dispatched every (SENSOR_SSSS_LATENCY) ms. Default is 20ms or 50Hz
 #define SENSOR_SSSS_RATE_DEBUG_GPIO      (1)    // Set to 1 to toggle configured GPIO
 
+/* Setting this MACRO to 1 enables sending a known sawtooth pattern as live-stream
+ * sensor data, this setting is intended for verifying communication interface
+ */
+#define SENSOR_COMMS_KNOWN_PATTERN (0) // 1 => Send a known sawtooth pattern for live-streaming
+
 /* Settings for selecting either Audio or an I2C sensor, Enable only one of these mode */
 #define SSI_SENSOR_SELECT_AUDIO    (0) // 1 => Select Audio data for live-streaming or recognition modes
 #define SSI_SENSOR_SELECT_SSSS     (1) // 1 => Select SSSS sensor data for live-streaming of recognition modes

--- a/qf_apps/qf_ssi_ai_app/sensor_audio/src/sensor_audio_process.c
+++ b/qf_apps/qf_ssi_ai_app/sensor_audio/src/sensor_audio_process.c
@@ -238,6 +238,11 @@ void audio_event_notifier(int pid, int event_type, void *p_event_data, int num_d
   printf("[AUDIO Event] PID=%d, event_type=%d, data=%02x\n", pid, event_type, p_data[0]);
 }
 
+#if (SENSOR_COMMS_KNOWN_PATTERN == 1)
+int16_t audio_debug_buffer[240]; // Buffer intended to send a known pattern such as sawtooth
+int16_t audio_debug_data = 0;    // state for holding current data for the known pattern
+#endif
+
 /* AUDIO livestream processing element functions */
 void audio_livestream_data_processor(
        QAI_DataBlock_t *pIn,
@@ -269,6 +274,16 @@ void audio_livestream_data_processor(
       sdi.bytes_per_reading = pIn->dbHeader.dataElementSize;
       sdi.vpData     = (void *)pIn->p_data;
 #endif
+
+#if (SENSOR_COMMS_KNOWN_PATTERN == 1)
+      // prepare the sawtooth known pattern data
+      for (int k = 0; k < nSamples; k++)
+      {
+          audio_debug_buffer[k] = audio_debug_data++;
+      }
+	  memcpy (pIn->p_data, audio_debug_buffer, nSamples * sizeof(int16_t));
+#endif
+
       ssi_publish_sensor_data(pIn->p_data, nSamples * (pIn->dbHeader.dataElementSize));
       //ble_send( &sdi );
     }


### PR DESCRIPTION
this pull request added a SENSOR_COMMS_KNOWN_PATTERN macro that enables or disable sending a known sawtooth pattern instead of actual sensor data. the feature is intended for verifying uart communication related issues