### PR TITLE
BSP/qomu: fix qomu_hardwaresetup declaration

### DIFF
--- a/BSP/qomu/inc/qomu_hardwaresetup.h
+++ b/BSP/qomu/inc/qomu_hardwaresetup.h
@@ -21,4 +21,4 @@
 *                                                          
 *=========================================================*/
 
-extern void qomu_hardwareSetup(void);
+extern void qomu_hardwaresetup(void);


### PR DESCRIPTION
There is a  inconsistency between function declaration (*BSP/inc/qomu_hardwaresetup.h*) and implementation (*BSP/src/qomu_hardwaresetup.c*). Former has an upper case 'S' and latter has an lower case 's'.

Due to this case issue a warning appear at compile time:
```
xxx/src/main.c: In function 'main':
xxx/src/main.c:22:2: warning: implicit declaration of function 'qomu_hardwaresetup'; did you mean 'qomu_hardwareSetup'? [-Wimplicit-function-declaration]
   22 |  qomu_hardwaresetup();
      |  ^~~~~~~~~~~~~~~~~~
      |  qomu_hardwareSetup
```

According to all examples name must be `qomu_hardwaresetup`.

Side question: **quickfeather** setup is called `qf_hardwareSetup` (uppercase 'S') why not using same naming convention for **Qomu**?