### PR TITLE
fix uart hal for spurious rx with floating rx pin

### DIFF
--- a/HAL/src/eoss3_hal_uart.c
+++ b/HAL/src/eoss3_hal_uart.c
@@ -437,13 +437,16 @@ void uart_isr_handler( int uartid )
             uart_vars.framing_err_count += 1;
             // FIX for UART Rx scenario when UART Cable from HOST is not connected to EOSS3:
             // (1) when the UART driver (from HOST) is not connected to the EOSS3 Rx pin,
-            // due to the Rx pin floating, we continuously get spurious rx bytes,
-            // all of which have a 'framing error' - hence, we should be ignoring these
-            // bytes, so 'return' from here, without adding the data bytes to the rx buffer.
-            // (2) Also, in this scenario, the spurious rx is continuous, so this interrupt keeps
-            // firing indefinitely, hogging the CPU completely - so, if the error count
-            // reaches a 'threshold' then disable the UART interrupts altogether.
-            // ideally, we get 0 framing errors in our use cases, so we use a nominal threshold of '5':
+            //       due to the Rx pin floating, we continuously get spurious rx bytes,
+            //       all of which have a 'framing error' - hence, we should be ignoring these
+            //       bytes, so 'return' from here, without adding the data bytes to the rx buffer.
+            // (2) also, in this scenario, the spurious rx is continuous, so this interrupt keeps
+            //       firing indefinitely, hogging the CPU completely - so, if the error count
+            //       reaches a 'threshold' then disable the UART interrupts altogether.
+            //     ideally, we get 0 framing errors in our use cases, so we use a nominal threshold of '5':
+            // NOTE: once we disable irqs here, we will no longer get any UART packets.
+            //   so, we cannot continue by just attaching the UART cable at this point, we will also need
+            //   to re-run the code from reset.
             if (uart_vars.framing_err_count >= 5)
             {
                 uart_disable_irqs();


### PR DESCRIPTION
### Symptom:

`qf_apps/qf_bootloader_uart` : if UART cable is not connected from HOST to the EOSS3 (specifically the Rx pin of the EOSS3): the board keeps resetting after pressing the 'USR' button, and never stays in the 'programming' mode.

### Cause:
EOSS3 gets Rx interrupts due to the UART Rx pin floating - the 'data' in the register is always '0' and the 'framing_error' bit is always set. This happens continuously and does not die down.
As the 'data' part of this is pushed into the Rx Buffer, the bootloader loop gets a '0' which is considered to be the 'boot' command in normal scenarios, causing the reset of the board.

### Fix:
2 parts:
1. For Rx Interrupts where the 'framing_error' is set, do not consider the 'data' part of the register as valid bytes, so add a 'return'
2. Also, when the 'framing_error' count reaches a threshold, disable the UART interrupts, otherwise the interrupt handler hogs the CPU indefinitely. A nominal threshold of '5' errors is currently used, as the ideal scenario is '0' errors.

### Test
Current:
1. Keep the UART cable unconnected to the QuickFeather, and then run the qf_bootloader_uart, and press 'USR' button to enter 'programming' mode:  board continuously resets
2. Keep the UART cable connected, and then run the qf_bootloader_uart and press 'USR' button to enter 'programming' mode: board works as expected (stays in 'programming' mode)

With Fix:

With either UART cable unconnected, or connected, with the qf_bootloader_uart, and press 'USR' button to enter 'programming' mode: the board works as expected (stays in 'progamming' mode)
 